### PR TITLE
Add setuptools

### DIFF
--- a/freva-client/pyproject.toml
+++ b/freva-client/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 "requests",
 "intake_esm",
 "rich",
+"setuptools",
 "tomli",
 "typer",
 ]

--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -17,5 +17,5 @@ need to apply data analysis plugins, please visit the
 from .auth import authenticate
 from .query import databrowser
 
-__version__ = "2408.0.0"
+__version__ = "2410.0.0"
 __all__ = ["authenticate", "databrowser", "__version__"]

--- a/freva-rest/src/freva_rest/__init__.py
+++ b/freva-rest/src/freva_rest/__init__.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-__version__ = "2408.0.0"
+__version__ = "2410.0.0"
 __all__ = ["__version__"]
 
 REST_URL = (


### PR DESCRIPTION
Something has changed upstream with pip. intake-esm needs setup tools, but it's no longer part of the python packaging. So we install it here. In metadata-inspector the theme thing happened: https://github.com/conda-forge/metadata-inspector-feedstock/pull/9