### PR TITLE
qf of the issue of opening the downloaded intake catalog

### DIFF
--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -17,5 +17,5 @@ need to apply data analysis plugins, please visit the
 from .auth import authenticate
 from .query import databrowser
 
-__version__ = "2410.0.0"
+__version__ = "2410.0.1"
 __all__ = ["authenticate", "databrowser", "__version__"]

--- a/freva-rest/src/databrowser_api/core.py
+++ b/freva-rest/src/databrowser_api/core.py
@@ -559,7 +559,7 @@ class SolrSearch:
                 }
                 for v in facets
             ],
-            "assets": {"column_name": "file", "format_column_name": "format"},
+            "assets": {"column_name": self.uniq_key, "format_column_name": "format"},
             "id": "freva",
             "description": f"Catalogue from freva-databrowser v{__version__}",
             "title": "freva-databrowser catalogue",

--- a/freva-rest/src/databrowser_api/core.py
+++ b/freva-rest/src/databrowser_api/core.py
@@ -125,6 +125,7 @@ class Translator:
             "fs_type",
             "grid_label",
             "grid_id",
+            "format",
         ]
 
     @property
@@ -558,7 +559,7 @@ class SolrSearch:
                 }
                 for v in facets
             ],
-            "assets": {"column_name": "uri", "format_column_name": "format"},
+            "assets": {"column_name": "file", "format_column_name": "format"},
             "id": "freva",
             "description": f"Catalogue from freva-databrowser v{__version__}",
             "title": "freva-databrowser catalogue",

--- a/freva-rest/src/freva_rest/__init__.py
+++ b/freva-rest/src/freva_rest/__init__.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-__version__ = "2410.0.0"
+__version__ = "2410.0.1"
 __all__ = ["__version__"]
 
 REST_URL = (


### PR DESCRIPTION

This pull request includes a quick updates to the `core.py` file to fix the issue of opening of the intake catalog that we download from `api/databrowser/intake_catalogue/{flavour}/file` endpoint

* Added the `format` field to the list of facets in the `facet_hierarchy` method
* Changed the `column_name` from `uri` to `file` in the `_create_intake_catalogue` method to correctly reference the asset column name