### PR TITLE
Introduce Freva backend agnosticism approach 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "dev-env/config"]
 	path = dev-env/config
 	url = https://github.com/FREVA-CLINT/freva-service-config.git
+	branch = opensearch-stac

--- a/dev-env/api_config.toml
+++ b/dev-env/api_config.toml
@@ -29,3 +29,35 @@ key_file = ""
 discovery_url = "http://localhost:8080/realms/freva/.well-known/openid-configuration"
 client_id = "freva"
 client_secret = ""
+
+
+
+## OpenSearch Configuration
+
+# [secondary-backend]
+
+# type = "SE"  # or "opensearch" or "postgres"
+# dns = "http://localhost:9203/items_*"
+# # Note: table and pagination_column are not required for SE backends
+
+# [secondary-backend.lookuptable]
+# project = "collection.keyword"
+# product = "properties.product.keyword"
+# institute = "properties.institute.keyword"
+# experiment = "properties.experiment.keyword"
+# time_min = "properties.start_datetime"
+# time_max = "properties.end_datetime"
+# variables = "properties.cube:variables"
+# file = "assets.data.href"
+# uri = "assets.data.href"
+
+# [secondary-backend.lookuptable.defaults]
+# project = "freva"
+# product = "freva"
+# institute = "JSC"
+# experiment = "STACBackendadoptation"
+# time_min = "1900-01-01T00:00:00Z"
+# time_max = "2100-12-31T23:59:59Z"
+# variables = "variable1"
+# file = "file"
+# uri = "uri"

--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -82,6 +82,36 @@ services:
     volumes:
       - ./config/mongo/mongo-userdata-init.js:/docker-entrypoint-initdb.d/mongo-userdata-init.js:ro
 
+  pgstac:
+    networks:
+      - freva-rest
+    image: ghcr.io/stac-utils/pgstac:latest
+    environment:
+      - POSTGRES_USER=pgstac
+      - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=postgis
+      - PGUSER=pgstac
+      - PGPASSWORD=password
+      - PGDATABASE=postgis
+    ports:
+      - "5432:5432"
+
+  opensearch:
+    networks:
+      - freva-rest
+    container_name: os-container
+    image: opensearchproject/opensearch:${OPENSEARCH_VERSION:-2.11.1}
+    hostname: opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - ./config/opensearch/opensearch.yml:/usr/share/opensearch/config/opensearch.yml
+    ports:
+      - "9203:9202"
+
+
 networks:
   freva-rest:
     driver: bridge

--- a/dev-env/ingest_stac_metadata.py
+++ b/dev-env/ingest_stac_metadata.py
@@ -1,0 +1,287 @@
+import json
+from datetime import datetime, timedelta
+import random
+import uuid
+import os
+from pypgstac.db import PgstacDB
+from pypgstac.load import Loader
+
+from opensearchpy import OpenSearch, RequestsHttpConnection, helpers as opensearch_helpers
+
+
+NUM_ITEMS = 100000 
+NUM_COLLECTIONS = 5
+
+def generate_test_data():
+    """Generate synthetic STAC test metadata."""
+    collections = {}
+    items = []
+    project = ["CMIP6", "CORDEX", "CMIP5", "CMIP7", "CORDEX-Adjust"]
+
+    for i in range(NUM_COLLECTIONS):
+        collection_id = project[i]
+        start_year = random.randint(1980, 2020)
+        end_year = start_year + random.randint(1, 10)
+        collections[collection_id] = {
+            "id": collection_id.lower(),
+            "stac_version": "1.0.0",
+            "type": "Collection",
+            "description": f"Test collection {i+1} for performance testing",
+            "license": "MIT",
+            "extent": {
+                "spatial": {
+                    "bbox": [[-180, -90, 180, 90]]
+                },
+                "temporal": {
+                    "interval": [[
+                        f"{start_year}-01-01T00:00:00Z", 
+                        f"{end_year}-12-31T23:59:59Z"
+                    ]]
+                }
+            },
+            "providers": [{
+                "name": f"Provider {i+1}",
+                "roles": ["producer", "processor"],
+                "url": f"https://www.freva.dkez.de"
+            }]
+        }
+
+    collection_counters = {coll: 0 for coll in project}
+
+    variables = ["temperature", "precipitation", "wind_speed", "humidity", "pressure"]
+    models = ["cesm2", "mpi-esm1-2-hr", "mpi-esm1-2-lr", 
+              "miroc-miroc6-clmcom-kit-cclm-6-0-clm2-v1", 
+              "ec-earth-consortium-ec-earth3-veg-clmcom-btu-icon-2-6-5-rc-nukleus-x2yn2-v1"]
+    experiments = ["historical", "rcp45", "rcp85", "ssp126", "ssp585"]
+    frequencies = ["daily", "monthly", "hourly", "yearly", "seasonal"]
+    
+    for i in range(NUM_ITEMS):
+        collection_id = project[i % NUM_COLLECTIONS]
+        collection = collections[collection_id]
+        count = collection_counters[collection_id]
+        item_id = f"item-{collection_id.lower()}-{count}"
+        collection_counters[collection_id] += 1
+        start_date_str = collection["extent"]["temporal"]["interval"][0][0]
+        end_date_str = collection["extent"]["temporal"]["interval"][0][1]
+        start_date = datetime.strptime(start_date_str, "%Y-%m-%dT%H:%M:%SZ")
+        end_date = datetime.strptime(end_date_str, "%Y-%m-%dT%H:%M:%SZ")
+        item_start = start_date + timedelta(days=random.randint(0, (end_date - start_date).days - 30))
+        item_end = item_start + timedelta(days=random.randint(1, 30))
+        item_start_str = item_start.strftime("%Y-%m-%dT%H:%M:%SZ")
+        item_end_str = item_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+        institute = f"institute-{random.randint(1, 10)}"
+        model = random.choice(models)
+        experiment = random.choice(experiments)
+        realization = f"r{random.randint(1, 5)}i{random.randint(1, 3)}p{random.randint(1, 3)}f{random.randint(1, 2)}"
+        frequency = random.choice(frequencies)
+        variable = random.choice(variables)
+        version = f"v{random.randint(2018, 2024)}{random.randint(1, 12):02d}{random.randint(1, 28):02d}"
+        href_path = f"/work/{institute}/{model}/{experiment}/{realization}/{frequency}/{variable}/{version}/{item_id}.nc"
+        item = {
+            "id": item_id,
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "collection": collection_id.lower(),
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]
+                ]]
+            },
+            "properties": {
+                "datetime": item_start_str,
+                "start_datetime": item_start_str,
+                "end_datetime": item_end_str,
+                "institute": institute,
+                "model": model,
+                "experiment": experiment,
+                "realization": realization,
+                "frequency": frequency,
+                "variable": variable,
+                "version": version
+            },
+            "assets": {
+                "data": {
+                    "href": href_path,
+                    "type": "application/x-netcdf",
+                    "roles": ["data"]
+                }
+            }
+        }
+        items.append(item)
+        
+        if (i + 1) % 10000 == 0:
+            print(f"Generated {i + 1} items...")
+
+    return {
+        "collections": collections,
+        "items": items
+    }
+
+
+class PgstacIngestor:
+    def __init__(self):
+        self.db_config = {
+            "POSTGRES_USER": os.getenv("POSTGRES_USER", "pgstac"),
+            "POSTGRES_PASSWORD": os.getenv("POSTGRES_PASSWORD", "secret"),
+            "PGHOST": os.getenv("PGHOST", "localhost"),
+            "POSTGRES_PORT": os.getenv("POSTGRES_PORT", "5432")
+        }
+
+    def create_dsn(self):
+        """Create database connection string"""
+        return f"postgresql://{self.db_config['POSTGRES_USER']}:{self.db_config['POSTGRES_PASSWORD']}@{self.db_config['PGHOST']}:{self.db_config['POSTGRES_PORT']}/postgis"
+
+    def ingest_data(self, stac_data):
+        """Ingest collections and items into pgSTAC"""
+        try:
+            db = PgstacDB(dsn=self.create_dsn(), debug=True)
+            loader = Loader(db)
+            collections = list(stac_data["collections"].values())
+            loader.load_collections(collections)
+
+            batch_size = 1000
+            items = stac_data["items"]
+            
+            for i in range(0, len(items), batch_size):
+                batch = items[i:i+batch_size]
+                loader.load_items(batch)
+                print(f"Loaded items {i+1} to {min(i+batch_size, len(items))}")
+            return True
+
+        except Exception as e:
+            return False
+
+class ElasticIngestor:
+    def __init__(self):
+        scheme = "https" if os.getenv("ES_USE_SSL", "false").lower() == "true" else "http"
+        host = os.getenv("ES_HOST", "localhost")
+        port = os.getenv("ES_PORT", "9203")
+        
+        self.es_config = {
+            "hosts": [{'host': host, 'port': int(port)}],
+            "use_ssl": scheme == "https",
+            "verify_certs": os.getenv("ES_VERIFY_CERTS", "false").lower() == "true",
+            "ssl_show_warn": False,
+            "headers": {"Content-Type": "application/json"},
+            "connection_class": RequestsHttpConnection,
+            "compatibility_mode": True
+        }
+        self.collections_index = os.getenv("STAC_COLLECTIONS_INDEX", "collections")
+        self.items_index_prefix = os.getenv("STAC_ITEMS_INDEX_PREFIX", "items")
+
+    def create_indices(self, client, collection_ids):
+        """Create or update necessary indices with mappings"""
+        base_mapping = {
+            "mappings": {
+                "properties": {
+                    "id": {"type": "keyword"},
+                    "collection": {"type": "keyword"},
+                    "properties": {
+                        "properties": {
+                            "experiment": {"type": "keyword"},
+                            "institute": {"type": "keyword"},
+                            "model": {"type": "keyword"},
+                            "variable": {"type": "keyword"},
+                            "frequency": {"type": "keyword"},
+                            "start_datetime": {"type": "date"},
+                            "end_datetime": {"type": "date"},
+                            "datetime": {"type": "date"}
+                        }
+                    },
+                    "assets": {
+                        "properties": {
+                            "data": {
+                                "properties": {
+                                    "href": {"type": "keyword"}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "settings": {
+                "number_of_shards": 1,
+                "number_of_replicas": 0
+            }
+        }
+        if not client.indices.exists(index=self.collections_index):
+            print(f"Creating index: {self.collections_index}")
+            client.indices.create(index=self.collections_index, body=base_mapping)
+        for collection_id in collection_ids:
+            items_index = f"{self.items_index_prefix}_{collection_id.lower()}"
+            if not client.indices.exists(index=items_index):
+                print(f"Creating index: {items_index}")
+                client.indices.create(index=items_index, body=base_mapping)
+
+    def ingest_data(self, stac_data):
+        """Ingest collections and items into OpenSearch"""
+
+            
+        try:
+            client = OpenSearch(**self.es_config)
+            self.create_indices(client, stac_data["collections"].keys())
+            collections_actions = [
+                {
+                    "_index": self.collections_index,
+                    "_id": collection["id"],
+                    "_source": collection
+                }
+                for collection in stac_data["collections"].values()
+            ]
+
+            opensearch_helpers.bulk(client, collections_actions)
+            print(f"Indexed {len(collections_actions)} collections")
+            batch_size = 1000
+            items = stac_data["items"]
+            
+            for i in range(0, len(items), batch_size):
+                batch = items[i:i+batch_size]
+                
+                batch_actions = [
+                    {
+                        "_index": f"{self.items_index_prefix}_{item['collection']}",
+                        "_id": item["id"],
+                        "_source": item
+                    }
+                    for item in batch
+                ]
+                
+                opensearch_helpers.bulk(client, batch_actions)
+                print(f"Indexed items {i+1} to {min(i+batch_size, len(items))}")
+            return True
+
+        except Exception as e:
+            return False
+
+def main():
+    stac_data = generate_test_data()
+    print("========== PostgreSQL PgSTAC Ingestion Test ==========")
+    import time
+    pg_start_time = time.time()
+    
+    pg_ingestor = PgstacIngestor()
+    pg_success = pg_ingestor.ingest_data(stac_data)
+    
+    pg_end_time = time.time()
+    pg_duration = pg_end_time - pg_start_time
+    
+    if pg_success:
+        print(f"PostgreSQL ingestion completed in {pg_duration:.2f} seconds")
+    
+
+    print("========== OpenSearch Ingestion Test ==========")
+    os_start_time = time.time()
+    
+    os_ingestor = ElasticIngestor()
+    os_success = os_ingestor.ingest_data(stac_data)
+    
+    os_end_time = time.time()
+    os_duration = os_end_time - os_start_time
+    
+    if os_success:
+        print(f"OpenSearch ingestion completed in {os_duration:.2f} seconds")
+
+if __name__ == "__main__":
+    main()
+

--- a/freva-rest/README.md
+++ b/freva-rest/README.md
@@ -39,6 +39,32 @@ cd freva-rest
 python -m pip install -e .[dev]
 ```
 
+## Secondary Backends
+
+Freva supports connecting to secondary backends for enhanced data management and search capabilities:
+
+- RDBMS Backends: Connect to PostgreSQL and other relational databases (e.g., pgSTAC and MySQL)
+- Search Engine Backends: Connect to Elasticsearch or OpenSearch
+
+To enable a secondary backend, uncomment and configure the appropriate section in your `api_config.toml` file:
+
+```toml
+[secondary-backend]
+type = "RDBMS" # Use "RDBMS" for relational databases or "SE" for search engines
+dns = "postgresql+asyncpg://user:password@localhost:5432/database"
+table = "table_name" # For RDBMS backends
+pagination_column = "id" # Column used for pagination (in RDBMS)
+limit_offset = "LIMIT :limit OFFSET :offset" # limit and offset order (in RDBMS)
+
+[secondary-backend.lookuptable]
+# Configure field mappings between Freva search keys and backend fields
+project = "collection"
+product = "content->'properties'->>'product'"
+# Additional mappings as needed
+```
+
+Or set the environment variables which are mentioned in the **Available Environment Variables** section.
+
 ## Freva-rest production docker container
 It's best to use the system in production within a dedicated docker container.
 You can pull the container from the GitHub container registry:
@@ -110,6 +136,14 @@ MYSQL_USER=
 MYSQL_PASSWORD=
 MYSQL_ROOT_PASSWORD=
 MYSQL_DATABASE= # Database name for legacy freva
+
+# Secondary Backend Configuration
+API_SECONDARY_BACKEND_TYPE=      # Type of backend: "RDBMS" or "SE" (Search Engine)
+API_SECONDARY_BACKEND_DNS=       # Connection string for the backend
+API_SECONDARY_BACKEND_TABLE=     # Table name for RDBMS backends (default: pgstac.items)
+API_SECONDARY_BACKEND_PAGINATION_COLUMN= # Column used for pagination (default: id)
+API_SECONDARY_BACKEND_LIMIT_OFFSET=     # SQL pagination syntax (default: LIMIT :limit OFFSET :offset)
+API_SECONDARY_BACKEND_LOOKUPTABLE=      # JSON mapping between Freva and backend fields
 
 # Service activation flags
 # Set to 1 to enable, 0 to disable the service (default)

--- a/freva-rest/pyproject.toml
+++ b/freva-rest/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 "typing_extensions",
 "uvicorn",
 "zarr<3",
+"sqlalchemy",
+"asyncpg",
+"greenlet",
 ]
 [project.scripts]
 freva-rest-server = "freva_rest.cli:cli"

--- a/freva-rest/src/freva_rest/api_config.toml
+++ b/freva-rest/src/freva_rest/api_config.toml
@@ -112,3 +112,102 @@ client_id = "freva"
 # Secret key associated with the client ID. Keep this secure as it is used to
 # authenticate the API to the OIDC provider.
 client_secret = ""
+
+
+### IMPORTANT: If you uncomment the whole configuration below, you can use 
+## the secondary-backend for connecting to all kind of Rational Database
+## Management System (RDBMS) backend and search engine (SE) backend like
+## Elasticsearch or OpenSearch. You can uncomment one of the following
+## sections based on the backend you want to connect to.
+
+# # PostgreSQL Configuration
+
+# [secondary-backend]
+# # (OPTIONAL)Secondary Backend configuration for connecting to
+# # all kind of Rational Database Management System (RDBMS) backend and 
+# # search engine (SE) backend like Elasticsearch or OpenSearch.
+# # You can uncomment one of the following sections based on the 
+# # backend you want to connect to.
+
+# # In the following examples we generally consider the native 
+# # backends of STAC, pgSTAC and ES and OS as use cases.
+
+# type = "RDBMS"
+# dns = "postgresql+asyncpg://pgstac:secret@localhost:5432/postgis"
+# table = "pgstac.items"
+# pagination_column = "id" # IMPORTANT: specify the column name for pagination
+# limit_offset = "LIMIT :limit OFFSET :offset" # IMPORTANT: One can specify the limit and offset variables based on the database-specific syntax
+
+# [secondary-backend.lookuptable]
+# # secondary-backend.lookuptable section defines the lookup table 
+# # mapping between secondary backend fields and the data search params
+# # used in the Freva-API. 
+# # This allows the API to query secondary backend as backend of the 
+# # Freva-API.
+
+# # For finding the supported Freva search keys you can have a look at 
+# # the Freva-API documentation.
+# # https://github.com/FREVA-CLINT/freva-service-config/blob/main/solr/managed-schema.xml
+# # Or be in contact with the Freva team at freva@dkrz.de
+
+# # For example to get more informeation regarding the syntax of JSON
+# # Postgres backend, please refer to the documentation.
+# # https://www.postgresql.org/docs/current/functions-json.html
+# project = "collection"
+# product = "content->'properties'->>'product'"
+# institute = "content->'properties'->>'institute'"
+# experiment = "content->'properties'->>'experiment'"
+# time_min = "content->'properties'->>'start_datetime'"
+# time_max = "content->'properties'->>'end_datetime'"
+# variables = "content->'properties'->'cube:variables'"
+# file = "content->'assets'->'data'->>'href'"
+# uri = "content->'assets'->'data'->>'href'"
+# fs_type = "content->'properties'->>'fs_type'"
+
+# [secondary-backend.lookuptable.defaults]
+# # This section defines the default values for the lookup table 
+# # mapping between secondary backend fields and the data search
+# # params used in the Freva-API.
+
+# project = "freva"
+# product = "freva"
+# institute = "JSC"
+# experiment = "STACBackendadoptation"
+# time_min = "1900-01-01T00:00:00Z"
+# time_max = "2100-12-31T23:59:59Z"
+# variables = "variable1"
+# file = "file"
+# uri = "uri"
+# fs_type = "posix"
+
+
+# # OpenSearch Configuration
+
+# [secondary-backend]
+
+# type = "SE"  # or "opensearch" or "postgres"
+# dns = "http://localhost:9203/items_*"
+# index = "items_*"
+# # Note: table and pagination_column are not required for SE backends
+
+# [secondary-backend.lookuptable]
+# project = "collection.keyword"
+# product = "properties.product.keyword"
+# institute = "properties.institute.keyword"
+# experiment = "properties.experiment.keyword"
+# time_min = "properties.start_datetime"
+# time_max = "properties.end_datetime"
+# variables = "properties.cube:variables"
+# file = "assets.data.href"
+# uri = "assets.data.href"
+
+# [secondary-backend.lookuptable.defaults]
+# project = "freva"
+# product = "freva"
+# institute = "JSC"
+# experiment = "STACBackendadoptation"
+# time_min = "1900-01-01T00:00:00Z"
+# time_max = "2100-12-31T23:59:59Z"
+# variables = "variable1"
+# file = "file"
+# uri = "uri"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ deps = -e ./freva-rest
        pytest-env
        setuptools
        xarray
+       pypgstac
+       opensearch-py
+       psycopg
+       psycopg_pool
 
 commands =
     pytest -vv --cov=freva-rest --cov=freva-client --cov=freva-data-portal-worker --cov-report=html:coverage_report --junitxml report.xml --cov-report xml tests/


### PR DESCRIPTION
This PR introduces a way to switch Freva’s default search backend from Solr to any available RDBMS or search engine backend using a simple configuration. If no secondary backend is set in the environment or `api_config.toml`, Solr will be used as a fallback. This makes Freva backend-agnostic, allowing it to work with different search backends.

Performance tests on STAC's native backends, pgSTAC and OpenSearch/ElasticSearch, show that it performs as well as Solr, with pgSTAC even performing better.

left:
Since this feature is needed for next week, Production tests on live STAC instances are still left but will be completed in the coming days.
