### PR TITLE
Improve logging and data-dirs.

### DIFF
--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -59,9 +59,6 @@ services:
       LDAP_DOMAIN: "example.com"
       LDAP_ADMIN_PASSWORD: "admin_password"
       LDAP_ADMIN_USERNAME: "admin"
-    ports:
-      - "389:389"
-      - "636:636"
     command: --copy-service
     hostname: ldap
     networks:

--- a/freva-data-portal-worker/pyproject.toml
+++ b/freva-data-portal-worker/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
 "rioxarray",
 "watchfiles",
 "xarray",
-"xpublish",
 "zarr<3",
 ]
 [project.scripts]

--- a/freva-data-portal-worker/pyproject.toml
+++ b/freva-data-portal-worker/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 "dask[distributed,diagnostics]",
 "h5netcdf",
 "jupyter-server-proxy",
+"packaging",
 "netcdf4",
 "rasterio",
 "redis",

--- a/freva-data-portal-worker/src/data_portal_worker/load_data.py
+++ b/freva-data-portal-worker/src/data_portal_worker/load_data.py
@@ -6,18 +6,21 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional, Tuple, TypedDict, cast
 
-import cloudpickle  # fades cloudpickle
-import redis  # fades redis
-import xarray as xr  # fades xarray
-from dask.distributed import LocalCluster  # fades distributed
-from dask.distributed import Client
+import cloudpickle
+import redis
+import xarray as xr
+from dask.distributed import Client, LocalCluster
 from xarray.backends.zarr import encode_zarr_variable
-from xpublish.utils.zarr import create_zmetadata  # fades xpublish
-from xpublish.utils.zarr import encode_chunk, get_data_chunk, jsonify_zmetadata
 from zarr.storage import array_meta_key
 
 from .backends import load_data
 from .utils import data_logger, str_to_int
+from .zarr_utils import (
+    create_zmetadata,
+    encode_chunk,
+    get_data_chunk,
+    jsonify_zmetadata,
+)
 
 ZARR_CONSOLIDATED_FORMAT = 1
 ZARR_FORMAT = 2
@@ -319,9 +322,7 @@ class ProcessQueue(DataLoadFactory):
         data_logger.debug(
             "Assigning %s to %s for future processing", inp_obj, uuid5
         )
-        data_cache: Optional[bytes] = cast(
-            Optional[bytes], self.cache.get(uuid5)
-        )
+        data_cache: Optional[bytes] = cast(Optional[bytes], self.cache.get(uuid5))
         status_dict: LoadDict = {
             "status": 2,
             "obj_path": f"/api/freva-data-portal/zarr/{uuid5}.zarr",

--- a/freva-data-portal-worker/src/data_portal_worker/zarr_utils.py
+++ b/freva-data-portal-worker/src/data_portal_worker/zarr_utils.py
@@ -1,0 +1,227 @@
+"""Utilities for working with zarr storages."""
+
+from copy import deepcopy
+from typing import Any, Dict, Literal, Optional, Union, cast
+
+import dask.array
+import numpy as np
+import xarray as xr
+from numcodecs.abc import Codec
+from numcodecs.compat import ensure_ndarray
+from xarray.backends.zarr import (
+    DIMENSION_KEY,
+    encode_zarr_attr_value,
+    encode_zarr_variable,
+    extract_zarr_variable_encoding,
+)
+from zarr.meta import encode_fill_value
+from zarr.storage import (
+    array_meta_key,
+    attrs_key,
+    default_compressor,
+    group_meta_key,
+)
+from zarr.util import normalize_shape
+
+from .utils import data_logger
+
+DaskArrayType = dask.array.Array
+ZARR_FORMAT = 2
+ZARR_CONSOLIDATED_FORMAT = 1
+ZARR_METADATA_KEY = ".zmetadata"
+
+
+def extract_dataarray_zattrs(da: xr.DataArray) -> Dict[str, Any]:
+    """helper function to extract zattrs dictionary from DataArray"""
+    zattrs = {}
+    for k, v in da.attrs.items():
+        zattrs[k] = encode_zarr_attr_value(v)
+    zattrs[DIMENSION_KEY] = list(da.dims)
+
+    # We don't want `_FillValue` in `.zattrs`
+    # It should go in `fill_value` section of `.zarray`
+    _ = zattrs.pop("_FillValue", None)
+
+    return zattrs
+
+
+def extract_dataset_zattrs(dataset: xr.Dataset) -> Dict[str, Any]:
+    """helper function to create zattrs dictionary from Dataset global attrs"""
+    zattrs = {}
+    for k, v in dataset.attrs.items():
+        zattrs[k] = encode_zarr_attr_value(v)
+    return zattrs
+
+
+def extract_dataarray_coords(
+    da: xr.DataArray,
+    zattrs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """helper function to extract coords from DataArray into a directionary"""
+    if da.coords:
+        # Coordinates are only encoded if there are non-dimension coordinates
+        nondim_coords = sorted(str(k) for k in (set(da.coords) - set(da.dims)))
+
+        if len(nondim_coords) > 0 and da.name not in nondim_coords:
+            coords = " ".join(nondim_coords)
+            zattrs["coordinates"] = encode_zarr_attr_value(coords)
+    return zattrs
+
+
+def extract_zarray(
+    da: xr.DataArray,
+    encoding: Dict[str, Any],
+    dtype: np.dtype[Any],
+) -> Dict[str, Any]:
+    """helper function to extract zarr array metadata."""
+
+    def _extract_fill_value(
+        da: xr.DataArray,
+        dtype: np.dtype[Any],
+    ) -> Any:
+        """helper function to extract fill value from DataArray."""
+        fill_value = da.attrs.pop("_FillValue", None)
+        return encode_fill_value(fill_value, dtype)
+
+    meta = {
+        "compressor": encoding.get(
+            "compressor", da.encoding.get("compressor", default_compressor)
+        ),
+        "filters": encoding.get("filters", da.encoding.get("filters", None)),
+        "chunks": encoding.get("chunks", None),
+        "dtype": dtype.str,
+        "fill_value": _extract_fill_value(da, dtype),
+        "order": "C",
+        "shape": list(normalize_shape(da.shape)),
+        "zarr_format": ZARR_FORMAT,
+    }
+
+    if meta["chunks"] is None:
+        meta["chunks"] = da.shape
+
+    # validate chunks
+    if isinstance(da.data, DaskArrayType):
+        var_chunks = tuple([c[0] for c in da.data.chunks])
+    else:
+        var_chunks = da.shape
+    if not var_chunks == tuple(meta["chunks"]):
+        raise ValueError(
+            "Encoding chunks do not match inferred chunks"
+        )  # pragma: no cover
+
+    meta["chunks"] = list(meta["chunks"])  # return chunks as a list
+
+    return meta
+
+
+def create_zmetadata(dataset: xr.Dataset) -> Dict[str, Any]:
+    """Helper function to create a consolidated zmetadata dictionary."""
+
+    zmeta: Dict[str, Any] = {
+        "zarr_consolidated_format": ZARR_CONSOLIDATED_FORMAT,
+        "metadata": {},
+    }
+    zmeta["metadata"][group_meta_key] = {"zarr_format": ZARR_FORMAT}
+    zmeta["metadata"][attrs_key] = extract_dataset_zattrs(dataset)
+
+    for key, dvar in dataset.variables.items():
+        da = dataset[key]
+        encoded_da = encode_zarr_variable(dvar, name=key)
+        encoding = extract_zarr_variable_encoding(
+            dvar, zarr_format=cast(Literal[2, 3], ZARR_FORMAT)
+        )
+        zattrs = extract_dataarray_zattrs(encoded_da)
+        zattrs = extract_dataarray_coords(da, zattrs)
+        zmeta["metadata"][f"{key}/{attrs_key}"] = zattrs
+        zmeta["metadata"][f"{key}/{array_meta_key}"] = extract_zarray(
+            encoded_da,
+            encoding,
+            encoded_da.dtype,
+        )
+
+    return zmeta
+
+
+def jsonify_zmetadata(
+    dataset: xr.Dataset,
+    zmetadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Helper function to convert zmetadata dictionary to a json
+    compatible dictionary.
+
+    """
+    zjson = deepcopy(zmetadata)
+
+    for key in list(dataset.variables):
+        # convert compressor to dict
+        compressor = zjson["metadata"][f"{key}/{array_meta_key}"]["compressor"]
+        if compressor is not None:
+            compressor_config = zjson["metadata"][f"{key}/{array_meta_key}"][
+                "compressor"
+            ].get_config()
+            zjson["metadata"][f"{key}/{array_meta_key}"][
+                "compressor"
+            ] = compressor_config
+
+    return zjson
+
+
+def encode_chunk(
+    chunk: np.typing.ArrayLike,
+    filters: Optional[list[Codec]] = None,
+    compressor: Optional[Codec] = None,
+) -> bytes:
+    """helper function largely copied from zarr.Array"""
+    # apply filters
+    if filters:
+        for f in filters:
+            chunk = f.encode(chunk)
+
+    # check object encoding
+    if ensure_ndarray(chunk).dtype == object:
+        raise RuntimeError("cannot write object array without object codec")
+
+    # compress
+    if compressor:
+        cdata = compressor.encode(chunk)
+    else:
+        cdata = ensure_ndarray(chunk).tobytes()
+
+    return cast(bytes, cdata)
+
+
+def get_data_chunk(
+    da: Union[xr.DataArray, DaskArrayType],
+    chunk_id: str,
+    out_shape: tuple[int, ...],
+) -> np.typing.NDArray[Any]:
+    """Get one chunk of data from this DataArray (da).
+
+    If this is an incomplete edge chunk, pad the returned array to match out_shape.
+    """
+    ikeys = tuple(map(int, chunk_id.split(".")))
+    if isinstance(da, DaskArrayType):
+        chunk_data = da.blocks[ikeys]
+    else:
+        if da.ndim > 0 and ikeys != ((0,) * da.ndim):
+            raise ValueError(
+                "Invalid chunk_id for numpy array: %s. Should have been: %s"
+                % (chunk_id, ((0,) * da.ndim))
+            )
+        chunk_data = np.asarray(da)
+
+    data_logger.debug(
+        "checking chunk output size, %s == %s" % (chunk_data.shape, out_shape)
+    )
+
+    if isinstance(chunk_data, DaskArrayType):
+        chunk_data = chunk_data.compute()
+
+    # zarr expects full edge chunks, contents out of bounds for the array are undefined
+    if chunk_data.shape != tuple(out_shape):
+        new_chunk = np.empty_like(chunk_data, shape=out_shape)
+        write_slice = tuple([slice(0, s) for s in chunk_data.shape])
+        new_chunk[write_slice] = chunk_data
+        return cast(np.typing.NDArray[Any], new_chunk)
+    else:
+        return cast(np.typing.NDArray[Any], chunk_data)

--- a/freva-rest/Dockerfile
+++ b/freva-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/condaforge/mambaforge AS base
+FROM quay.io/condaforge/mambaforge
 ARG VERSION
 LABEL org.opencontainers.image.authors="DRKZ-CLINT"
 LABEL org.opencontainers.image.source="https://github.com/FREVA-CLINT/freva-nextgen/freva-rest"
@@ -18,30 +18,30 @@ ENV API_CONFIG=/opt/freva-rest/api_config.toml \
     USE_SOLR=0 \
     USE_REDIS=0 \
     USE_MYSQL=0 \
-    API_LOGDIR=/var/log/freva-rest-server
+    API_LOGDIR=/var/log/freva-rest-server \
+    PATH=/opt/conda/bin:/usr/local/bin:$PATH
 
 
-FROM base AS builder
-WORKDIR /opt/app
+RUN mkdir -p /docker-entrypoint-initdb.d && \
+    mamba install -y -q -c conda-forge --override-channels freva-rest-server
+WORKDIR /tmp/app
 COPY . .
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir build && \
     python3 -m build --sdist --wheel
 
-FROM base AS final
 WORKDIR /opt/freva-rest
-COPY --from=builder /opt/app/dist /opt/app/dist
 COPY src/freva_rest/api_config.toml $API_CONFIG
-ENV PATH=/opt/conda/bin:/usr/local/bin:$PATH
 
-RUN mkdir -p /docker-entrypoint-initdb.d && \
-    mamba install -y -q -c conda-forge --override-channels freva-rest-server && \
-    python3 -m pip install --no-cache-dir /opt/app/dist/freva_rest*.whl
+RUN /opt/conda/bin/python3 -m pip install -I --no-deps --no-cache-dir /tmp/app/dist/freva_rest*.whl && \
+    rm -fr /tmp/app
 
 COPY --chmod=0755 docker-scripts/entrypoint.sh /docker-entrypoint-initdb.d/entrypoint.sh
 COPY --chmod=0755 docker-scripts/follow /usr/local/bin/follow
 COPY docker-scripts/logging.sh /usr/local/lib/logging.sh
-RUN mkdir -p /var/data /var/log/freva-rest-server && chmod -R 2666 /var/log /var/data
+RUN mkdir -p /var/data /var/log/freva-rest-server && \
+    chmod -R 2777 /var/log /var/data &&\
+    ln -s /opt/conda/libexec/apache-solr/server/logs /tmp/solr
 
 ENTRYPOINT ["/docker-entrypoint-initdb.d/entrypoint.sh"]
 CMD ["freva-rest-server"]

--- a/freva-rest/Dockerfile
+++ b/freva-rest/Dockerfile
@@ -8,6 +8,8 @@ ENV API_CONFIG=/opt/freva-rest/api_config.toml \
     CONDA_PREFIX=/opt/conda \
     API_SOLR_CORE=files \
     API_PORT=7777 \
+    API_REDIS_SSL_CERTFILE=/certs/client-cert.pem \
+    API_REDIS_SSL_KEYFILE=/certs/client-key.pem \
     API_SOLR_HOST=localhost:8983 \
     API_MONGO_HOST=localhost:27017 \
     API_OIDC_CLIENT_ID=freva \
@@ -15,7 +17,9 @@ ENV API_CONFIG=/opt/freva-rest/api_config.toml \
     USE_MONGODB=0 \
     USE_SOLR=0 \
     USE_REDIS=0 \
-    USE_MYSQL=0
+    USE_MYSQL=0 \
+    API_LOGDIR=/var/log/freva-rest-server
+
 
 FROM base AS builder
 WORKDIR /opt/app
@@ -29,6 +33,7 @@ WORKDIR /opt/freva-rest
 COPY --from=builder /opt/app/dist /opt/app/dist
 COPY src/freva_rest/api_config.toml $API_CONFIG
 ENV PATH=/opt/conda/bin:/usr/local/bin:$PATH
+
 RUN mkdir -p /docker-entrypoint-initdb.d && \
     mamba install -y -q -c conda-forge --override-channels freva-rest-server && \
     python3 -m pip install --no-cache-dir /opt/app/dist/freva_rest*.whl
@@ -36,7 +41,7 @@ RUN mkdir -p /docker-entrypoint-initdb.d && \
 COPY --chmod=0755 docker-scripts/entrypoint.sh /docker-entrypoint-initdb.d/entrypoint.sh
 COPY --chmod=0755 docker-scripts/follow /usr/local/bin/follow
 COPY docker-scripts/logging.sh /usr/local/lib/logging.sh
-RUN mkdir -p /logs && chmod -R 2666 /logs
+RUN mkdir -p /var/data /var/log/freva-rest-server && chmod -R 2666 /var/log /var/data
 
 ENTRYPOINT ["/docker-entrypoint-initdb.d/entrypoint.sh"]
 CMD ["freva-rest-server"]

--- a/freva-rest/README.md
+++ b/freva-rest/README.md
@@ -59,12 +59,15 @@ The container supports several startup modes:
 docker run \
     -e API_OIDC_DISCOVERY_URL=https://example-oicd.org/.well-known/openid-configuration \
     -p 7777:7777 \
+    -v my-data-dir:/var/data
     ghcr.io/freva-clint/freva-rest:latest
 
 # Start with custom freva-rest flags and access
 docker run \
         -e API_OIDC_DISCOVERY_URL=https://example-oicd.org/.well-known/openid-configuration \
         -p 8000:8000
+        -v my-data-dir:/var/data
+        -v my-log-dir:/var/log
        ghcr.io/freva-clint/freva-rest:latest -p 8000
 
 ```
@@ -141,10 +144,9 @@ The container can use several persistent volumes that should be mounted:
 docker run -d \
   --name freva-rest \
   -e {above envs} \
-  -v $(pwd)/mongodb_data:/data/db \
-  -v $(pwd)/solr_data:/var/solr \
+  -v $(pwd)/freva-rest-server/data:/var/data \
+  -v $(pwd)/freva-rest-server/logs:/var/log \
   -v $(pwd)/certs:/certs:ro \
-  -v $(pwd)/logs:/logs \
   -p 7777:7777 \
   -p 27017:27017 \
   -p 8983:8983 \
@@ -154,7 +156,7 @@ docker run -d \
 
 Create the necessary directories before starting the container:
 ```console
-mkdir -p {mongodb_data,solr_data,certs}
+mkdir -p {freva-rest-server/data,freva-rest-server/logs,certs}
 ```
 
 > [!NOTE]

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -21,10 +21,11 @@ init_mongodb() {
     done
     mkdir -p /var/data/mongodb /var/log/mongodb
     API_DATA_DIR=/var/data/mongodb\
-        API_LOG_DIR=/var/log/mongodb /bin/bash /opt/conda/libexec/freva-rest-server/scripts/init-mongo
+        API_LOG_DIR=/var/log/mongodb\
+        API_CONFIG_DIR=/tmp/mongodb /bin/bash /opt/conda/libexec/freva-rest-server/scripts/init-mongo
     log_info "Starting MongoDB with authentication..."
     /opt/conda/bin/mongod \
-        -f /opt/conda/share/freva-rest-server/mongodb/mongod.yaml \
+        -f /tmp/mongodb/mongod.yaml \
         --auth \
         --cpu 1> /dev/null 2> /var/log/mongodb/mongodb.err.log &
 }
@@ -33,6 +34,7 @@ init_solr() {
     log_service "Initialising Solr"
     ulimit -n 65000 || echo "Warning: Unable to set ulimit -n 65000"
     mkdir -p /var/data/solr /var/log/solr
+    export SOLR_LOGS_DIR=/var/log/solr
     API_DATA_DIR=/var/data/solr /opt/conda/libexec/freva-rest-server/scripts/init-solr
     log_info "Starting solr service"
     nohup /opt/conda/bin/solr start -force -Dsolr.log.dir=/var/log/solr 1> /dev/null 2> /var/log/solr/solr.err &

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -51,10 +51,13 @@ init_solr() {
     ulimit -n 65000 || echo "Warning: Unable to set ulimit -n 65000"
     mkdir -p /var/data/solr /var/log/solr
     export SOLR_LOGS_DIR=/var/log/solr
+    export SOLR_HEAP=${SOLR_HEAP:-4g}
+    export SOLR_PID_DIR=/tmp
+    export SOLR_JETTY_HOST=0.0.0.0
+    export SOLR_PORT=8983
     API_DATA_DIR=/var/data/solr /opt/conda/libexec/freva-rest-server/scripts/init-solr
     log_info "Starting solr service"
-    nohup /opt/conda/bin/solr start -force -Dsolr.log.dir=/var/log/solr 1> /dev/null 2> /var/log/solr/solr.err &
-    SOLR_PORT=${API_SOLR_PORT:-8983}
+    nohup /opt/conda/bin/solr start -force -s /var/data/solr  1> /dev/null 2> /var/log/solr/solr.err &
     timeout 60 bash -c 'until curl -s http://localhost:'"$SOLR_PORT"'/solr/admin/ping;do sleep 2; done' || {
             echo "Error: Solr did not start within 60 seconds." >&2
             exit 1

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -79,8 +79,20 @@ init_mysql(){
     mkdir -p /var/data/mysqldb /var/log/mysqldb
     API_DATA_DIR=/var/data/mysqldb \
         API_LOG_DIR=/var/log/mysqldb /opt/conda/libexec/freva-rest-server/scripts/init-mysql
+    TRY=0
+    MAX_TRIES=10
+    while [ -z "$(ps aux |grep mysqld|grep -v grep)" ]; do
+        if [ "$TRY" -ge "$MAX_TRIES" ]; then
+            log_error "Timeout: MySQL server didn't stop properly."
+            exit 1
+        fi
+        let TRY=TRY+1
+        log_info "Waiting for init MySQL to shut down..."
+        sleep 1
+    done
+    sleep 3
     log_info "Starting mysql service"
-    nohup /opt/conda/bin/mysqld --user=$(whoami) --no-defaults --datadir=/var/data/mysqldb > /var/log/myslqdb/mysqld.log 2>&1 &
+    nohup /opt/conda/bin/mysqld --user=$(whoami) --bind-address=0.0.0.0 --datadir=/var/data/mysqldb > /var/log/mysqldb/mysqld.log 2>&1 &
 }
 
 init() {

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -8,7 +8,7 @@ check_env(){
     shift
     local service_name=$@
     if [[ -z ${!var_name:-} ]];then
-        log_error "In order to set up $service_name you must set the '\$${var_name:-}' environment variable." >&2
+        log_error "In order to set up $service_name you must set the '\$${var_name:-}' environment variable."
         exit 1
     fi
 }

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -53,8 +53,8 @@ init_solr() {
     export SOLR_LOGS_DIR=/var/log/solr
     export SOLR_HEAP=${SOLR_HEAP:-4g}
     export SOLR_PID_DIR=/tmp
-    export SOLR_JETTY_HOST=0.0.0.0
-    export SOLR_PORT=8983
+    export SOLR_JETTY_HOST=${SOLR_HOST:-0.0.0.0}
+    export SOLR_PORT=${SOLR_PORT:-8983}
     API_DATA_DIR=/var/data/solr /opt/conda/libexec/freva-rest-server/scripts/init-solr
     log_info "Starting solr service"
     nohup /opt/conda/bin/solr start -force -s /var/data/solr  1> /dev/null 2> /var/log/solr/solr.err &

--- a/freva-rest/docker-scripts/entrypoint.sh
+++ b/freva-rest/docker-scripts/entrypoint.sh
@@ -28,7 +28,6 @@ init_mongodb() {
     MAX_TRIES=10
     while [ -f /tmp/mongodb/mongod.pid ]; do
         PID=$(cat /tmp/mongodb/mongod.pid)
-        echo $PID $(ps $PID) foo
         if [ -z "$PID" ] || [ -z "$(ps -p $PID --no-headers)" ];then
             break
         fi
@@ -79,7 +78,7 @@ init_mysql(){
     done
     mkdir -p /var/data/mysqldb /var/log/mysqldb
     API_DATA_DIR=/var/data/mysqldb \
-        LOG_DIR=/var/log/mysqldb /opt/conda/libexec/freva-rest-server/scripts/init-mysql
+        API_LOG_DIR=/var/log/mysqldb /opt/conda/libexec/freva-rest-server/scripts/init-mysql
     log_info "Starting mysql service"
     nohup /opt/conda/bin/mysqld --user=$(whoami) --no-defaults --datadir=/var/data/mysqldb > /var/log/myslqdb/mysqld.log 2>&1 &
 }

--- a/freva-rest/docker-scripts/follow
+++ b/freva-rest/docker-scripts/follow
@@ -10,16 +10,16 @@ for service in "$@"; do
     service_lower=$(echo "$service" | tr '[:upper:]' '[:lower:]')
     case "${service_lower}" in
         "mongo"|"mongodb"|"mongod")
-            log_file="/logs/mongodb.log"
+            log_file="/var/log/mongodb/mongod.log"
             ;;
         "mysql"|"mysqld")
-            log_file="/logs/mysqld.log"
+            log_file="/var/log/mysqldb/mysqld.log"
             ;;
         "redis")
-            log_file="/logs/reids.log"
+            log_file="/var/log/cache/redis.log"
             ;;
         "solr")
-            log_file="/logs/solr.log"
+            log_file="/var/log/solr/solr.log"
             ;;
         "*")
             log_error "Error: '$service' is not a valid service. Allowed: ${VALID_SERVICES[*]}"

--- a/freva-rest/src/freva_rest/config.py
+++ b/freva-rest/src/freva_rest/config.py
@@ -23,7 +23,7 @@ from typing import (
     cast,
 )
 
-import requests
+import httpx
 import tomli
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pydantic import BaseModel, Field
@@ -44,9 +44,7 @@ class ServerConfig(BaseModel):
         Union[str, Path],
         Field(
             title="API Config",
-            description=(
-                "Path to a .toml file holding the API" "configuration"
-            ),
+            description=("Path to a .toml file holding the API" "configuration"),
         ),
     ] = os.getenv("API_CONFIG", Path(__file__).parent / "api_config.toml")
     proxy: Annotated[
@@ -230,16 +228,12 @@ class ServerConfig(BaseModel):
         self.mongo_host = self.mongo_host or self._read_config(
             "mongo_db", "hostname"
         )
-        self.mongo_user = self.mongo_user or self._read_config(
-            "mongo_db", "user"
-        )
+        self.mongo_user = self.mongo_user or self._read_config("mongo_db", "user")
         self.mongo_password = self.mongo_password or self._read_config(
             "mongo_db", "password"
         )
         self.mongo_db = self.mongo_db or self._read_config("mongo_db", "name")
-        self.solr_host = self.solr_host or self._read_config(
-            "solr", "hostname"
-        )
+        self.solr_host = self.solr_host or self._read_config("solr", "hostname")
         self.solr_core = self.solr_core or self._read_config("solr", "core")
         self.redis_user = self.redis_user or self._read_config("cache", "user")
         self.redis_password = self.redis_password or self._read_config(
@@ -270,9 +264,7 @@ class ServerConfig(BaseModel):
     @property
     def services(self) -> Set[str]:
         """Define the services that are served."""
-        return set(
-            s.strip() for s in self.api_services.split(",") if s.strip()
-        )
+        return set(s.strip() for s in self.api_services.split(",") if s.strip())
 
     @property
     def redis_url(self) -> str:
@@ -326,7 +318,7 @@ class ServerConfig(BaseModel):
         """Query the url overview from OIDC Service."""
         if self._oidc_overview is not None:
             return self._oidc_overview
-        res = requests.get(self.oidc_discovery_url, verify=False, timeout=3)
+        res = httpx.get(self.oidc_discovery_url, verify=False, timeout=3)
         res.raise_for_status()
         self._oidc_overview = res.json()
         return self._oidc_overview
@@ -386,14 +378,12 @@ class ServerConfig(BaseModel):
     def _get_solr_fields(self) -> Iterator[str]:
         url = f"{self.get_core_url(self.solr_cores[-1])}/schema/fields"
         try:
-            for entry in requests.get(url, timeout=5).json().get("fields", []):
+            for entry in httpx.get(url, timeout=5).json().get("fields", []):
                 if entry["type"] in ("extra_facet", "text_general") and entry[
                     "name"
                 ] not in ("file_name", "file", "file_no_version"):
                     yield entry["name"]
-        except (
-            requests.exceptions.ConnectionError
-        ) as error:  # pragma: no cover
+        except httpx.RequestError as error:  # pragma: no cover
             logger.error(
                 "Connection to %s failed: %s", url, error
             )  # pragma: no cover

--- a/freva-rest/src/freva_rest/config.py
+++ b/freva-rest/src/freva_rest/config.py
@@ -44,9 +44,7 @@ class ServerConfig(BaseModel):
         Union[str, Path],
         Field(
             title="API Config",
-            description=(
-                "Path to a .toml file holding the API" "configuration"
-            ),
+            description=("Path to a .toml file holding the API" "configuration"),
         ),
     ] = os.getenv("API_CONFIG", Path(__file__).parent / "api_config.toml")
     proxy: Annotated[
@@ -230,16 +228,12 @@ class ServerConfig(BaseModel):
         self.mongo_host = self.mongo_host or self._read_config(
             "mongo_db", "hostname"
         )
-        self.mongo_user = self.mongo_user or self._read_config(
-            "mongo_db", "user"
-        )
+        self.mongo_user = self.mongo_user or self._read_config("mongo_db", "user")
         self.mongo_password = self.mongo_password or self._read_config(
             "mongo_db", "password"
         )
         self.mongo_db = self.mongo_db or self._read_config("mongo_db", "name")
-        self.solr_host = self.solr_host or self._read_config(
-            "solr", "hostname"
-        )
+        self.solr_host = self.solr_host or self._read_config("solr", "hostname")
         self.solr_core = self.solr_core or self._read_config("solr", "core")
         self.redis_user = self.redis_user or self._read_config("cache", "user")
         self.redis_password = self.redis_password or self._read_config(
@@ -270,9 +264,7 @@ class ServerConfig(BaseModel):
     @property
     def services(self) -> Set[str]:
         """Define the services that are served."""
-        return set(
-            s.strip() for s in self.api_services.split(",") if s.strip()
-        )
+        return set(s.strip() for s in self.api_services.split(",") if s.strip())
 
     @property
     def redis_url(self) -> str:
@@ -392,7 +384,8 @@ class ServerConfig(BaseModel):
                 ] not in ("file_name", "file", "file_no_version"):
                     yield entry["name"]
         except (
-            requests.exceptions.ConnectionError
+            requests.exceptions.ConnectionError,
+            requests.exceptions.JSONDecodeError,
         ) as error:  # pragma: no cover
             logger.error(
                 "Connection to %s failed: %s", url, error

--- a/freva-rest/src/freva_rest/databrowser_api/endpoints.py
+++ b/freva-rest/src/freva_rest/databrowser_api/endpoints.py
@@ -3,11 +3,7 @@
 from typing import Annotated, Any, Dict, List, Literal, Union
 
 from fastapi import Body, Depends, HTTPException, Query, Request, status
-from fastapi.responses import (
-    JSONResponse,
-    PlainTextResponse,
-    StreamingResponse,
-)
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from freva_rest.auth import TokenPayload, auth
@@ -277,7 +273,7 @@ async def load_data(
         ),
     ] = None,
     request: Request = Required,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> StreamingResponse:
     """Search for datasets and stream the results as zarr.
 
@@ -326,7 +322,7 @@ async def load_data(
 )
 async def post_user_data(
     request: Annotated[AddUserDataRequestBody, Body(...)],
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> Dict[str, str]:
     """Index your own metadata and make it searchable.
 
@@ -385,7 +381,7 @@ async def delete_user_data(
             }
         ],
     ),
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> Dict[str, str]:
     """This endpoint lets you delete metadata that has been indexed."""
 

--- a/freva-rest/src/freva_rest/databrowser_api/endpoints.py
+++ b/freva-rest/src/freva_rest/databrowser_api/endpoints.py
@@ -3,7 +3,11 @@
 from typing import Annotated, Any, Dict, List, Literal, Union
 
 from fastapi import Body, Depends, HTTPException, Query, Request, status
-from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from fastapi.responses import (
+    JSONResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
 from pydantic import BaseModel, Field
 
 from freva_rest.auth import TokenPayload, auth

--- a/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
+++ b/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
@@ -99,15 +99,11 @@ async def get_status(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> JSONResponse:
     """Get the status of a loading process."""
-    meta: Dict[str, Any] = await read_redis_data(
-        uuid5, "status", timeout=timeout
-    )
-    return JSONResponse(
-        content={"status": meta}, status_code=status.HTTP_200_OK
-    )
+    meta: Dict[str, Any] = await read_redis_data(uuid5, "status", timeout=timeout)
+    return JSONResponse(content={"status": meta}, status_code=status.HTTP_200_OK)
 
 
 @app.get(
@@ -137,7 +133,7 @@ async def zemtadata(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> JSONResponse:
     """Consolidate zarr metadata
 
@@ -182,7 +178,7 @@ async def zgroup(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> JSONResponse:
     """Zarr group data.
 
@@ -228,7 +224,7 @@ async def zattrs(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> JSONResponse:
     """Get zarr Attributes.
 
@@ -271,9 +267,7 @@ async def chunk_data(
     ],
     chunk: Annotated[
         str,
-        Path(
-            title="chunk", description="The chnuk number that should be read."
-        ),
+        Path(title="chunk", description="The chnuk number that should be read."),
     ],
     timeout: Annotated[
         int,
@@ -285,7 +279,7 @@ async def chunk_data(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required),
+    current_user: TokenPayload = Depends(auth.required_dependency()),
 ) -> Response:
     """Get a zarr array chunk.
 

--- a/freva-rest/src/freva_rest/logger.py
+++ b/freva-rest/src/freva_rest/logger.py
@@ -9,8 +9,10 @@ import rich.logging
 from rich.console import Console
 
 THIS_NAME: str = "freva-rest"
-LOG_DIR: Path = Path(os.environ.get("API_LOGDIR") or Path(f"/tmp/log/{THIS_NAME}"))
-logfmt = "%(name)s - %(message)s"
+LOG_DIR: Path = Path(
+    os.environ.get("API_LOGDIR") or Path(f"/tmp/log/{THIS_NAME}")
+)
+logfmt = "%(asctime)s %(levelname)s %(name)s - %(message)s"
 datefmt = "%Y-%m-%dT%H:%M"
 LOG_DIR.mkdir(exist_ok=True, parents=True)
 logger_format = logging.Formatter(logfmt, datefmt)

--- a/freva-rest/src/freva_rest/logger.py
+++ b/freva-rest/src/freva_rest/logger.py
@@ -12,10 +12,12 @@ THIS_NAME: str = "freva-rest"
 LOG_DIR: Path = Path(
     os.environ.get("API_LOGDIR") or Path(f"/tmp/log/{THIS_NAME}")
 )
-logfmt = "%(asctime)s %(levelname)s %(name)s - %(message)s"
+logfmt = "%(name)s - %(message)s"
 datefmt = "%Y-%m-%dT%H:%M"
 LOG_DIR.mkdir(exist_ok=True, parents=True)
-logger_format = logging.Formatter(logfmt, datefmt)
+logger_format = logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s - %(message)s", datefmt
+)
 logger_file_handle = RotatingFileHandler(
     LOG_DIR / f"{THIS_NAME}.log",
     mode="a",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ env = [
     "API_CONFIG={PWD}/freva-rest/src/freva_rest/api_config.toml",
 
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = ["ignore::UserWarning"]
 [tool.flake8]
 ignore = ["F405", "F403"]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,11 +9,25 @@ import requests
 from pytest_mock import MockFixture
 
 from freva_client.auth import Auth, authenticate
+from freva_rest.auth import CustomAuth
 
 
 def raise_for_status() -> None:
     """Mock function used for requests result rais_for_status method."""
     raise requests.HTTPError("Invalid")
+
+
+def test_missing_ocid_server() -> None:
+    """Test the behviour of a missing ocid server."""
+    wrong_auth = CustomAuth("")
+    assert wrong_auth._auth is None
+    with pytest.raises():
+        wrong_auth.required("")
+
+    wrong_auth = CustomAuth("http://example.org/bar")
+    assert wrong_auth._auth is None
+    with pytest.raises():
+        wrong_auth.required("")
 
 
 def test_authenticate_with_password(
@@ -27,9 +41,7 @@ def test_authenticate_with_password(
             "token_type": "Bearer",
             "expires": int(datetime.now(timezone.utc).timestamp() + 3600),
             "refresh_token": "test_refresh_token",
-            "refresh_expires": int(
-                datetime.now(timezone.utc).timestamp() + 7200
-            ),
+            "refresh_expires": int(datetime.now(timezone.utc).timestamp() + 7200),
             "scope": "profile email address",
         }
         with mocker.patch(
@@ -39,9 +51,7 @@ def test_authenticate_with_password(
             auth_instance.authenticate(host="https://example.com")
         assert isinstance(auth_instance._auth_token, dict)
         assert auth_instance._auth_token["access_token"] == "test_access_token"
-        assert (
-            auth_instance._auth_token["refresh_token"] == "test_refresh_token"
-        )
+        assert auth_instance._auth_token["refresh_token"] == "test_refresh_token"
     finally:
         auth_instance._auth_token = old_token_data
 
@@ -70,9 +80,7 @@ def test_authenticate_with_refresh_token(
 
         assert isinstance(auth_instance._auth_token, dict)
         assert auth_instance._auth_token["access_token"] == "test_access_token"
-        assert (
-            auth_instance._auth_token["refresh_token"] == "test_refresh_token"
-        )
+        assert auth_instance._auth_token["refresh_token"] == "test_refresh_token"
     finally:
         auth_instance._auth_token = old_token_data
 
@@ -106,16 +114,12 @@ def test_refresh_token(mocker: MockFixture, auth_instance: Auth) -> None:
 
         assert isinstance(auth_instance._auth_token, dict)
         assert auth_instance._auth_token["access_token"] == "new_access_token"
-        assert (
-            auth_instance._auth_token["refresh_token"] == "new_refresh_token"
-        )
+        assert auth_instance._auth_token["refresh_token"] == "new_refresh_token"
     finally:
         auth_instance._auth_token = old_token_data
 
 
-def test_authenticate_function(
-    mocker: MockFixture, auth_instance: Auth
-) -> None:
+def test_authenticate_function(mocker: MockFixture, auth_instance: Auth) -> None:
     """Test the authenticate function with username and password."""
     old_token_data = deepcopy(auth_instance._auth_token)
     token_data = {
@@ -272,7 +276,5 @@ def test_token_status(test_server: str, auth: Dict[str, str]) -> None:
 
 def test_get_overview(test_server: str) -> None:
     """Test the open id connect discovery endpoint."""
-    res = requests.get(
-        f"{test_server}/auth/v2/.well-known/openid-configuration"
-    )
+    res = requests.get(f"{test_server}/auth/v2/.well-known/openid-configuration")
     assert res.status_code == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,7 @@ def test_auth(
         )
         assert res.exit_code == 0
         assert res.stdout
+        print(res.stdout)
         assert "access_token" in json.loads(res.stdout)
     finally:
         auth_instance._auth_token = old_token

--- a/tests/test_load_zarr.py
+++ b/tests/test_load_zarr.py
@@ -76,7 +76,8 @@ def test_load_files_success(test_server: str, auth: Dict[str, str]) -> None:
         files[0],
         engine="zarr",
         storage_options={"headers": {"Authorization": f"Bearer {token}"}},
-    ).load()
+    )
+    dset.load()
     assert "ua" in dset
     data = requests.get(
         f"{files[0]}/.zattrs",

--- a/tests/test_load_zarr.py
+++ b/tests/test_load_zarr.py
@@ -18,7 +18,7 @@ def test_auth(test_server: str) -> None:
         f"{test_server}/auth/v2/token",
         data={"username": "foo", "password": "bar"},
     )
-    assert res1.status_code == 404
+    assert res1.status_code == 401
     res2 = requests.post(
         f"{test_server}/auth/v2/token",
         data={

--- a/tests/test_zarr_utils.py
+++ b/tests/test_zarr_utils.py
@@ -1,0 +1,182 @@
+"""Tests for testing the zarr utilities."""
+
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+from data_portal_worker.zarr_utils import (
+    encode_chunk,
+    extract_dataarray_coords,
+    get_data_chunk,
+)
+
+
+class DummyCodec:
+    """Dummy codec class to test the coding."""
+
+    def __init__(self, name="", dtype=float):
+        self.name = name
+        self.dtype = dtype
+
+    def encode(self, data):
+        if isinstance(data, bytes):
+            data = np.frombuffer(data, dtype=self.dtype)
+        return (data + 1).tobytes()
+
+
+def test_encode_chunk_with_filters_and_compressor() -> None:
+    data = np.array([1, 2, 3])
+    filters = [DummyCodec(dtype=data.dtype), DummyCodec(dtype=data.dtype)]
+    compressor = DummyCodec(dtype=data.dtype)
+
+    result = encode_chunk(data, filters=filters, compressor=compressor)
+    expected = data + 2 + 1
+
+    np.testing.assert_array_equal(
+        np.frombuffer(result, dtype=data.dtype), expected
+    )
+
+
+def test_encode_chunk_without_filters() -> None:
+    data = np.array([1, 2, 3])
+    compressor = DummyCodec(dtype=data.dtype)
+
+    result = encode_chunk(data, filters=None, compressor=compressor)
+    expected = data + 1
+
+    np.testing.assert_array_equal(result, expected.tobytes())
+
+
+def test_encode_chunk_with_object_array_raises() -> None:
+    data = np.array(["a", "b", "c"], dtype=object)
+
+    with pytest.raises(RuntimeError, match="cannot write object array"):
+        encode_chunk(data)
+
+
+def test_encode_chunk_without_filters_or_compressor() -> None:
+    data = np.array([1, 2, 3])
+    result = encode_chunk(data)
+    np.testing.assert_array_equal(result, data.tobytes())
+
+
+def test_get_data_chunk_numpy() -> None:
+    da = xr.DataArray(np.arange(6).reshape(2, 3))
+    result = get_data_chunk(da, "0.0", (2, 3))
+    np.testing.assert_array_equal(result, da.values)
+
+
+def test_get_data_chunk_numpy_invalid_chunk_id() -> None:
+    da = xr.DataArray(np.arange(6).reshape(2, 3))
+
+    with pytest.raises(ValueError, match="Invalid chunk_id"):
+        get_data_chunk(da, "1.0", (2, 3))
+
+
+def test_get_data_chunk_numpy_with_padding() -> None:
+    da = xr.DataArray(np.array([[1, 2]]))
+    out_shape = (2, 3)
+    result = get_data_chunk(da, "0.0", out_shape)
+
+    expected = np.empty(out_shape, dtype=da.dtype)
+    expected[:1, :2] = da.values
+
+    np.testing.assert_array_equal(result[:1, :2], expected[:1, :2])
+
+
+def test_get_data_chunk_dask() -> None:
+
+    darr = da.from_array(np.arange(4).reshape(2, 2), chunks=(1, 2))
+    data = xr.DataArray(darr)
+
+    result = get_data_chunk(data.data, "0.0", (1, 2))
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_array_equal(result, np.array([[0, 1]]))
+
+
+def test_get_data_chunk_dask_with_padding() -> None:
+
+    darr = da.from_array(np.array([[1, 2]]), chunks=(1, 2))
+    data = xr.DataArray(darr)
+
+    result = get_data_chunk(data, "0.0", (2, 3))
+
+    expected = np.empty((2, 3), dtype=data.dtype)
+    expected[:1, :2] = np.array([[1, 2]])
+    np.testing.assert_array_equal(result[:1, :2], expected[:1, :2])
+
+
+@patch(
+    "data_portal_worker.zarr_utils.encode_zarr_attr_value",
+    side_effect=lambda x: f"encoded:{x}",
+)
+def test_extract_with_nondim_coords(mock_encode) -> None:
+    da = xr.DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=("x", "y"),
+        coords={
+            "x": [10, 20],
+            "y": [100, 200],
+            "lat": (("x", "y"), [[1.0, 1.1], [1.2, 1.3]]),
+            "lon": (("x", "y"), [[2.0, 2.1], [2.2, 2.3]]),
+        },
+        name="temperature",
+    )
+
+    zattrs = {}
+    result = extract_dataarray_coords(da, zattrs)
+
+    # Should encode "lat lon" (sorted) into zattrs["coordinates"]
+    assert result["coordinates"] == "encoded:lat lon"
+    mock_encode.assert_called_once_with("lat lon")
+
+
+@patch("data_portal_worker.zarr_utils.encode_zarr_attr_value")
+def test_extract_with_only_dim_coords(mock_encode) -> None:
+    da = xr.DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=("x", "y"),
+        coords={
+            "x": [0, 1],
+            "y": [0, 1],
+        },
+        name="mydata",
+    )
+
+    zattrs = {}
+    result = extract_dataarray_coords(da, zattrs)
+
+    # Should not add 'coordinates' key
+    assert "coordinates" not in result
+    mock_encode.assert_not_called()
+
+
+@patch("data_portal_worker.zarr_utils.encode_zarr_attr_value")
+def test_extract_when_name_is_in_coords(mock_encode) -> None:
+    da = xr.DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=("x", "y"),
+        coords={
+            "x": [0, 1],
+            "y": [0, 1],
+            "temperature": (("x", "y"), [[5, 6], [7, 8]]),
+        },
+        name="temperature",
+    )
+
+    zattrs = {}
+    result = extract_dataarray_coords(da, zattrs)
+
+    # 'temperature' is in coords and matches name => should not encode
+    assert "coordinates" not in result
+    mock_encode.assert_not_called()
+
+
+def test_extract_with_no_coords() -> None:
+    da = xr.DataArray(data=[1, 2, 3], dims="x", name="a")
+
+    result = extract_dataarray_coords(da, {"foo": "bar"})
+    assert result == {"foo": "bar"}


### PR DESCRIPTION
This is a small PR that aims at unifying log and data output. The idea is that we can only use `-v data:/var/data` `-v logs:/var/log` to have the data and the logs of all services persist.

Note that I didn't for a unified folder such as `-v my-container-data:/var/freva-rest-server` and under `/var/freva-rest-server/` we have a `data` and `log` dir because it would make things even more easy but it would also break the volume structure of the current freva deployments, and backwards portability  is key.