### PR TITLE
switch to the most recent zarr version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dev-env/mongodb
 dev-env/certs
 *keycloakdb.lock.db
 *keycloakdb.*
+.DS_Store

--- a/freva-data-portal-worker/pyproject.toml
+++ b/freva-data-portal-worker/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 "rioxarray",
 "watchfiles",
 "xarray",
-"zarr<3",
+"zarr",
 ]
 [project.scripts]
 data-loader-worker = "data_portal_worker:cli.run_data_loader"

--- a/freva-data-portal-worker/src/data_portal_worker/load_data.py
+++ b/freva-data-portal-worker/src/data_portal_worker/load_data.py
@@ -11,7 +11,7 @@ import redis
 import xarray as xr
 from dask.distributed import Client, LocalCluster
 from xarray.backends.zarr import encode_zarr_variable
-from zarr.storage import array_meta_key
+from zarr.core.common import ZARRAY_JSON
 
 from .backends import load_data
 from .utils import data_logger, str_to_int
@@ -229,7 +229,7 @@ class DataLoadFactory:
         """Read the zarr metadata from the cache."""
         pickle_data, dset = self.load_object(key)
         meta = cast(Dict[str, Any], pickle_data["meta"])
-        arr_meta = meta["metadata"][f"{variable}/{array_meta_key}"]
+        arr_meta = meta["metadata"][f"{variable}/{ZARRAY_JSON}"]
         data = encode_chunk(
             get_data_chunk(
                 encode_zarr_variable(

--- a/freva-rest/pyproject.toml
+++ b/freva-rest/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 "tomli",
 "typing_extensions",
 "uvicorn",
-"zarr<3",
+"zarr",
 ]
 [project.scripts]
 freva-rest-server = "freva_rest.cli:cli"

--- a/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
+++ b/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
@@ -8,7 +8,7 @@ import cloudpickle
 from fastapi import Depends, Path, Query, status
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse, Response
-from zarr.storage import array_meta_key, attrs_key, group_meta_key
+from zarr.core.common import ZARRAY_JSON, ZATTRS_JSON, ZGROUP_JSON
 
 from freva_rest.auth import TokenPayload, auth
 from freva_rest.rest import app
@@ -285,14 +285,14 @@ async def chunk_data(
 
     This method reads the zarr data."""
 
-    if array_meta_key in chunk or attrs_key in chunk:
+    if ZARRAY_JSON in chunk or ZATTRS_JSON in chunk:
         json_meta: Dict[str, Any] = await read_redis_data(
             uuid5, "json_meta", timeout=timeout
         )
-        if attrs_key in chunk:
-            key = f"{variable}/{attrs_key}"
+        if ZATTRS_JSON in chunk:
+            key = f"{variable}/{ZATTRS_JSON}"
         else:
-            key = f"{variable}/{array_meta_key}"
+            key = f"{variable}/{ZARRAY_JSON}"
         try:
             content = json_meta["metadata"][key]
         except KeyError as error:
@@ -301,7 +301,7 @@ async def chunk_data(
             content=content,
             status_code=status.HTTP_200_OK,
         )
-    if group_meta_key in chunk:
+    if ZGROUP_JSON in chunk:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Sub groups are not supported.",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ def create_rasterio_file(temp_dir: str) -> str:
 def create_zarr_file(temp_dir: str) -> str:
     """Create a zarr dataset."""
     temp = os.path.join(temp_dir, "out.zarr")
-    zarr.convenience.save(temp, [1, 2, 3, 4])
+    zarr.save(temp, np.array([1, 2, 3, 4]))
     return temp
 
 


### PR DESCRIPTION
This morning, while working on the STAC-API endpoint development, I encountered an issue after refreshing my environment. The zarr dependency began throwing errors and was not functioning properly, which ended up blocking my developement. To resolve this, I had to dig into the library and make some necessary fixes.

In this small PR, we’ve reverted from `zarr<3` back to the latest release of `zarr`, and all related adjustments have been made accordingly.

When I was doing this changes, I noticed that in `Zarr-3`, most of the core functions have been refactored to be asynchronous. So, if we plan to fully adopt Zarr-3 and use its generic functionality, the proper long-term solution would be to refactor our data loader worker functions to be async as well, allowing us to `await` Zarr's internal async methods properly.

But, I still strongly fan for maintaining our own `zarr_utils` abstraction instead of relying directly on Zarr’s generics funcs. The Zarr codebase tends to introduce breaking changes frequently and without much notice, which can easily disrupt our workflow and break core functionality.