### PR TITLE
Zarr streaming pagination for web

### DIFF
--- a/dev-env/api_config.toml
+++ b/dev-env/api_config.toml
@@ -28,4 +28,4 @@ key_file = ""
 [oidc]
 discovery_url = "http://localhost:8080/realms/freva/.well-known/openid-configuration"
 client_id = "freva"
-client_secret = "secret"
+client_secret = ""

--- a/dev-env/api_config.toml
+++ b/dev-env/api_config.toml
@@ -28,4 +28,4 @@ key_file = ""
 [oidc]
 discovery_url = "http://localhost:8080/realms/freva/.well-known/openid-configuration"
 client_id = "freva"
-client_secret = ""
+client_secret = "secret"

--- a/freva-rest/src/freva_rest/databrowser_api/core.py
+++ b/freva-rest/src/freva_rest/databrowser_api/core.py
@@ -1205,7 +1205,18 @@ class Solr:
                 )
             except Exception as error:
                 logger.error("Cloud not connect to redis: %s", error)
-                yield "Internal error, service not available\n"
+                if catalogue_type == "intake":
+                    intake_error_dict: Dict[str, List[Sized]] = {
+                        self.uniq_key: ["Internal error, service not available"],
+                        "format": ["zarr"],
+                    }
+                    processed = self._process_catalogue_result(intake_error_dict)
+                    prefix = "   "
+                    suffix = "," if num < num_results else ""
+                    output = json.dumps(processed, indent=3)
+                    yield f"{prefix}{output}{suffix}\n"
+                else:
+                    yield "Internal error, service not available\n"
                 continue
             output = f"{api_path}/{uuid5}.zarr"
             if catalogue_type == "intake":

--- a/freva-rest/src/freva_rest/databrowser_api/endpoints.py
+++ b/freva-rest/src/freva_rest/databrowser_api/endpoints.py
@@ -294,7 +294,9 @@ async def extended_search(
     zarr_stream: bool = False,
     facets: Annotated[Union[List[str], None], SolrSchema.params["facets"]] = None,
     request: Request = Required,
-    current_user: Optional[TokenPayload] = Depends(auth.optional_dependency()),
+    current_user: Optional[TokenPayload] = Depends(
+        auth.create_auth_dependency(required=False)
+    )
 ) -> JSONResponse:
     """This endpoint is used by the databrowser web ui client."""
 
@@ -350,7 +352,7 @@ async def load_data(
         ),
     ] = None,
     request: Request = Required,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> StreamingResponse:
     """Search for datasets and stream the results as zarr.
 
@@ -399,7 +401,7 @@ async def load_data(
 )
 async def post_user_data(
     request: Annotated[AddUserDataRequestBody, Body(...)],
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> Dict[str, str]:
     """Index your own metadata and make it searchable.
 
@@ -458,7 +460,7 @@ async def delete_user_data(
             }
         ],
     ),
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> Dict[str, str]:
     """This endpoint lets you delete metadata that has been indexed."""
 

--- a/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
+++ b/freva-rest/src/freva_rest/freva_data_portal/endpoints.py
@@ -102,7 +102,7 @@ async def get_status(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> JSONResponse:
     """Get the status of a loading process."""
     meta: Dict[str, Any] = await read_redis_data(uuid5, "status", timeout=timeout)
@@ -136,7 +136,7 @@ async def zemtadata(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> JSONResponse:
     """Consolidate zarr metadata
 
@@ -179,7 +179,7 @@ async def zgroup(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> JSONResponse:
     """Zarr group data.
 
@@ -223,7 +223,7 @@ async def zattrs(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> JSONResponse:
     """Get zarr Attributes.
 
@@ -276,7 +276,7 @@ async def chunk_data(
             le=1500,
         ),
     ] = 1,
-    current_user: TokenPayload = Depends(auth.required_dependency()),
+    current_user: TokenPayload = Depends(auth.create_auth_dependency()),
 ) -> Response:
     """Get a zarr array chunk.
 

--- a/freva-rest/src/freva_rest/rest.py
+++ b/freva-rest/src/freva_rest/rest.py
@@ -26,7 +26,7 @@ from typing import AsyncIterator
 from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.requests import Request
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 
 from freva_rest import __version__
 
@@ -59,6 +59,10 @@ metadata_tags = [
     {
         "name": "Authentication",
         "description": "These endpoints are for authentication.",
+    },
+    {
+        "name": "System",
+        "description": "System utility endpoints for monitoring and diagnostics.",
     },
 ]
 
@@ -108,6 +112,20 @@ async def custom_redoc_ui_html(request: Request) -> HTMLResponse:
         openapi_url="/api/freva-nextgen/help/openapi.json",
         title="Freva RestAPI",
         redoc_favicon_url="/favicon.ico",
+    )
+
+
+@app.get(
+    "/api/freva-nextgen/ping",
+    tags=["System"],
+    summary="Health check endpoint"
+)
+async def ping(request: Request) -> JSONResponse:
+    """Health check endpoint that returns
+        `pong` when the API is operational."""
+    return JSONResponse(
+        content={"ping": "pong"},
+        status_code=200,
     )
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,11 +26,17 @@ def test_missing_ocid_server(test_server: str) -> None:
             "freva_rest.auth.auth.discovery_url",
             url,
         ):
-            res = requests.get(
+            res1 = requests.get(
                 f"{test_server}/auth/v2/status",
                 headers={"Authorization": "Bearer foo"},
             )
-            assert res.status_code == 503
+            assert res1.status_code == 503
+            # mock the optional auth in extended search endpoint
+            res2 = requests.get(
+                f"{test_server}/databrowser/extended-search/cmip6/uri",
+                headers={"Authorization": "Bearer foo"},
+            )
+            assert res2.status_code == 200
 
 
 def test_authenticate_with_password(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,6 +10,11 @@ def test_help_page(test_server: str) -> None:
     res = requests.get(f"{test_server}/help")
     assert "redoc" in res.text.lower()
 
+def test_health(test_server: str) -> None:
+    """Test if the health check works."""
+    res = requests.get(f"{test_server}/ping")
+    assert res.status_code == 200
+    assert res.json() == {"ping": "pong"}
 
 def test_favicon(test_server: str) -> None:
     """Test if the favicon works."""

--- a/tests/test_query_data_restapi.py
+++ b/tests/test_query_data_restapi.py
@@ -254,20 +254,31 @@ def test_extended_search(test_server: str) -> None:
     ).json()
     assert len(res8["search_results"]) == 1
 
-    res8 = requests.get(
+    res9 = requests.get(
         f"{test_server}/databrowser/extended-search/cmip6/uri",
         params={"facets": "activity_id", "max-results": 1, "zarr_stream": True}
     )
-    assert res8.status_code == 401
+    assert res9.status_code == 401
     with mock.patch("freva_rest.databrowser_api.core.create_redis_connection", None):
-        res9 = requests.get(
+        res10 = requests.get(
             f"{test_server}/databrowser/extended-search/cmip6/uri",
             params={"facets": "activity_id", "max-results": 1, "zarr_stream": True},
             headers={
                 "Authorization": f"Bearer {token_res.json()['access_token']}"
             },
         ).json()
-        assert res9["search_results"][0]["uri"] == "Internal error, service not able to publish"
+        assert res10["search_results"][0]["uri"] == "Internal error, service not able to publish"
+
+    with mock.patch(
+        "freva_rest.rest.server_config.api_services",
+        "databrowser"
+    ):
+        res11 = requests.get(
+            f"{test_server}/databrowser/extended-search/cmip6/uri",
+            params={"facets": "activity_id", "max-results": 1, "zarr_stream": True}
+        )
+        # get the normal response
+        assert res11.status_code == 200
 def test_metadata_search(test_server: str) -> None:
     """Test the facet search functionality."""
     res1 = requests.get(


### PR DESCRIPTION
In this PR we are going to add the zarr-streaming parameter in the `extended-search` endpoint for web purposes.
In the beginning I decided to paginate the `load` endpoint to have max-result on each params, to be able to see the zarr steam `uri`s on the file container of databrowser. But while it was totally feasible, then I found, adding pagination on an streaming endpoint, won't be a good idea since we don't use the generic param of the search engine and we can only stop the iteration via designing a counter. I didn't feel good about that approach. So I went through adding the `zarr-stream` param in `extended-search`
To achieve the final goal on web, another important thing has been changed! `required_dependency`: Since `extended-search` now works with(for zarr-streaming) and without authentication, we needed an optional auth instance creation. So i went through adding optional argument to this function.


Now one off-topic idea: when I was implementing this, another thing that crossed to my mind, it's concatenating the `data-search` with `load`, `intake-catalog` and `stac-catalogue`. With this idea, we can simply add a `zarr-stream=True` and `catalogue-type=intake/stac` parameters in data search endpoint and enable and cover the whole functionality of the `load` , `intake-catalog` and `stac-catalogue` endpoints in data-search which makes our codebase way leaner. 
What do you think about this idea?