### PR TITLE
Remove trailing slash from zarr stream url.

### DIFF
--- a/freva-client/src/freva_client/utils/databrowser_utils.py
+++ b/freva-client/src/freva_client/utils/databrowser_utils.py
@@ -141,7 +141,7 @@ class Config:
     @property
     def zarr_loader_url(self) -> str:
         """Define the url for getting zarr files."""
-        return f"{self.databrowser_url}/load/{self.flavour}/"
+        return f"{self.databrowser_url}/load/{self.flavour}"
 
     @property
     def intake_url(self) -> str:


### PR DESCRIPTION
A bug that went unnoticed and just got apparent with the new nginx config. I am not fully sure what happens. The trailing `/` causes the restAPI to trigger a redirect response 307.