### PR TITLE
Filter NaN values from grouped facet values

### DIFF
--- a/freva-client/src/freva_client/query.py
+++ b/freva-client/src/freva_client/query.py
@@ -721,9 +721,9 @@ class databrowser:
                 for k, v in self._facet_search(extended_search=True).items()
             ], columns=["facet", "values"])
             .explode("values")
-            .dropna(subset=["values"])
-            .groupby("facet")["values"]
-            .apply(list)
+            .groupby("facet")["values"].apply(
+                lambda x: [v for v in x if pd.notna(v)]
+            )
         )
 
     @classmethod
@@ -909,9 +909,9 @@ class databrowser:
                 ], columns=["facet", "values"]
             )
             .explode("values")
-            .dropna(subset=["values"])
-            .groupby("facet")["values"]
-            .apply(list)
+            .groupby("facet")["values"].apply(
+                lambda x: [v for v in x if pd.notna(v)]
+            )
         )
 
     @classmethod


### PR DESCRIPTION
A user raised a point that looked valid to me about the new Pandas DataFrame structure on the python and cli: 

> when a search is empty, it should return an empty list (`[]`) instead of `NaN` or `null`.

And the other and main reason of this PR is that by filtering out `NaN` values, we maintain full backward compatibility.

If those point looks valid to you could you please then have a look at the changes

An empty example:
how it looks now on the python

```python
In [9]: db.metadata_search(project='cmip6', product='dcpp', institute='ec-earth', host="****:7777")
Out[9]: 
facet
ensemble            []
experiment          []
institute           []
model               []
product             []
project             []
realm               []
time_aggregation    []
time_frequency      []
variable            []
Name: values, dtype: object
```

how on cli:
```bash
❯ freva-client databrowser metadata-search project=cmip6 product=dcpp institute=ec-earth  --host ****:7777
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃ facet            ┃ values ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ ensemble         │        │
│ experiment       │        │
│ institute        │        │
│ model            │        │
│ product          │        │
│ project          │        │
│ realm            │        │
│ time_aggregation │        │
│ time_frequency   │        │
│ variable         │        │
└──────────────────┴────────┘
```