### PR TITLE
feat: logout option to the CLI and Python authorization

### DIFF
--- a/docs/source/auth/auth-lib.rst
+++ b/docs/source/auth/auth-lib.rst
@@ -8,13 +8,14 @@ with the authentication system.
 
 .. autofunction:: freva_client.authenticate
 
+.. autofunction:: freva_client.logout
+
 .. _auth_cli:
 
 Using the command line interface
 ================================
 
-Token creation and refreshing can also be achieved with help of the ``auth``
-sub command of the command line interface
+Token creation and logout can be achieved with the ``auth`` sub command:
 
 .. code:: console
 
@@ -27,16 +28,22 @@ sub command of the command line interface
    res = run(["freva-client", "auth", "--help"], check=True, stdout=PIPE, stderr=PIPE)
    print(res.stdout.decode())
 
-You can create a token using your user name and password. 
+Login
+-----
+
+Create an OAuth2 access and refresh token:
+
+.. code:: console
+
+    freva-client auth login
 
 In the process of token generation, you would want to store your token data *securely*
 in a file, and use it as a refresh token to create new ones, eventually:
 
 .. code:: console
 
-    freva-client auth  > ~/.mytoken.json
-    chmod 600  ~/.mytoken.json
-
+    freva-client auth login > ~/.mytoken.json
+    chmod 600 ~/.mytoken.json
 
 For security reasons you cannot pass your password as an argument to the command line
 interface. This means that, in a *non-interactive* session such as a batch job, you
@@ -46,10 +53,25 @@ will have two options:
 2. Or, if you want to create a new one, you will *only* be able to do it with help
    of an already pre-existing valid refresh token.
 
-   .. code:: console
+.. code:: console
 
-       freva-client auth --token-file ~/.my_old_token.json > ~/.my_new_token.json
-       chmod 600 ~/.my_new_token.json
+    freva-client auth login --token-file ~/.my_old_token.json > ~/.my_new_token.json
+    chmod 600 ~/.my_new_token.json
+
+Force token recreation even if current token is valid:
+
+.. code:: console
+
+    freva-client auth login --force
+
+Logout
+------
+
+Clear local tokens and revoke server session:
+
+.. code:: console
+
+    freva-client auth logout
 
 
 .. warning::

--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -15,8 +15,8 @@ need to apply data analysis plugins, please visit the
 official documentation: https://freva-org.github.io/freva-legacy
 """
 
-from .auth import authenticate
+from .auth import authenticate, logout
 from .query import databrowser
 
 __version__ = "2510.0.0"
-__all__ = ["authenticate", "databrowser", "__version__"]
+__all__ = ["authenticate", "logout", "databrowser", "__version__"]

--- a/freva-client/src/freva_client/cli/auth_cli.py
+++ b/freva-client/src/freva_client/cli/auth_cli.py
@@ -14,11 +14,12 @@ from .cli_utils import version_callback
 
 auth_app = typer.Typer(
     name="auth",
-    help="Create OAuth2 access and refresh token.",
+    help="Authentication commands for OAuth2 tokens.",
     pretty_exceptions_short=False,
 )
 
 
+@auth_app.command("login")
 @exception_handler
 def authenticate_cli(
     host: Optional[str] = typer.Option(
@@ -47,14 +48,14 @@ def authenticate_cli(
     timeout: int = typer.Option(
         30,
         "--timeout",
-        help="Set the timeout for login in secdonds, 0 for indefinate",
+        help="Set the timeout for login in seconds, 0 for indefinite",
     ),
     verbose: int = typer.Option(0, "-v", help="Increase verbosity", count=True),
     version: Optional[bool] = typer.Option(
         False,
         "-V",
         "--version",
-        help="Show version an exit",
+        help="Show version and exit",
         callback=version_callback,
     ),
 ) -> None:
@@ -67,3 +68,36 @@ def authenticate_cli(
         timeout=timeout,
     )
     print(json.dumps(token, indent=3))
+
+
+@auth_app.command("logout")
+@exception_handler
+def logout_cli(
+    host: Optional[str] = typer.Option(
+        None,
+        "--host",
+        help=(
+            "Set the hostname of the databrowser, if not set (default) "
+            "the hostname is read from a config file"
+        ),
+    ),
+    token_file: str = typer.Option(
+        os.getenv(TOKEN_ENV_VAR, "").strip(),
+        "--token-file",
+        help="Path to the token file to delete",
+    ),
+    verbose: int = typer.Option(0, "-v", help="Increase verbosity", count=True),
+    version: Optional[bool] = typer.Option(
+        False,
+        "-V",
+        "--version",
+        help="Show version and exit",
+        callback=version_callback,
+    ),
+) -> None:
+    """Logout and clear authentication tokens."""
+    logger.set_verbosity(verbose)
+    auth = Auth(token_file=token_file or get_default_token_file())
+    auth._logout(host=host)
+
+    print("Logged out successfully. All tokens have been cleared.")

--- a/freva-client/src/freva_client/cli/cli_app.py
+++ b/freva-client/src/freva_client/cli/cli_app.py
@@ -7,7 +7,7 @@ import typer
 
 from freva_client.utils import logger
 
-from .auth_cli import authenticate_cli
+from .auth_cli import auth_app
 from .cli_utils import APP_NAME, version_callback
 from .databrowser_cli import databrowser_app
 
@@ -37,4 +37,4 @@ def main(
 
 
 app.add_typer(databrowser_app, name="databrowser")
-app.command(name="auth", help=authenticate_cli.__doc__)(authenticate_cli)
+app.add_typer(auth_app, name="auth")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,11 +152,18 @@ def setup_server() -> Iterator[str]:
 @pytest.fixture(scope="function", autouse=True)
 def user_cache_dir() -> Iterator[str]:
     """Mock the default user token file."""
-    with NamedTemporaryFile(suffix=".json") as temp_f:
-        with mock.patch.dict(
-            os.environ, {TOKEN_ENV_VAR: temp_f.name}, clear=False
-        ):
-            yield temp_f.name
+    # since logout remove the file, we need to keep the delete=False
+    # and remove it manually
+    with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
+        temp_path = temp_f.name
+        try:
+            with mock.patch.dict(
+                os.environ, {TOKEN_ENV_VAR: temp_path}, clear=False
+            ):
+                yield temp_path
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -397,21 +397,23 @@ def test_cli_logout(
 
     mocker.patch("webbrowser.open", return_value=True)
 
+    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
+    token_path = Path(temp_f.name)
+    temp_f.close()
+
     try:
-        with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
-            token_path = Path(temp_f.name)
-            token_path.write_text(json.dumps(mock_token_data()))
-            auth_instance._auth_token = mock_token_data()
+        token_path.write_text(json.dumps(mock_token_data()))
+        auth_instance._auth_token = mock_token_data()
 
-            with patch.dict(os.environ, {TOKEN_ENV_VAR: str(token_path), "BROWSER_SESSION": "1"}, clear=False):
-                res = cli_runner.invoke(
-                    cli_app,
-                    ["auth", "logout", "--host", test_server, "--token-file", str(token_path)]
-                )
+        with patch.dict(os.environ, {TOKEN_ENV_VAR: str(token_path), "BROWSER_SESSION": "1"}, clear=False):
+            res = cli_runner.invoke(
+                cli_app,
+                ["auth", "logout", "--host", test_server, "--token-file", str(token_path)]
+            )
 
-            assert res.exit_code == 0
-            assert "Logged out successfully" in res.stdout
-            assert not token_path.exists()
+        assert res.exit_code == 0
+        assert "Logged out successfully" in res.stdout
+        assert not token_path.exists()
     finally:
         auth_instance._auth_token = old_token
         if token_path.exists():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -397,23 +397,21 @@ def test_cli_logout(
 
     mocker.patch("webbrowser.open", return_value=True)
 
-    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
-    token_path = Path(temp_f.name)
-    temp_f.close()
-
     try:
-        token_path.write_text(json.dumps(mock_token_data()))
-        auth_instance._auth_token = mock_token_data()
+        with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
+            token_path = Path(temp_f.name)
+            token_path.write_text(json.dumps(mock_token_data()))
+            auth_instance._auth_token = mock_token_data()
 
-        with patch.dict(os.environ, {TOKEN_ENV_VAR: str(token_path), "BROWSER_SESSION": "1"}, clear=False):
-            res = cli_runner.invoke(
-                cli_app,
-                ["auth", "logout", "--host", test_server, "--token-file", str(token_path)]
-            )
+            with patch.dict(os.environ, {TOKEN_ENV_VAR: str(token_path), "BROWSER_SESSION": "1"}, clear=False):
+                res = cli_runner.invoke(
+                    cli_app,
+                    ["auth", "logout", "--host", test_server, "--token-file", str(token_path)]
+                )
 
-        assert res.exit_code == 0
-        assert "Logged out successfully" in res.stdout
-        assert not token_path.exists()
+            assert res.exit_code == 0
+            assert "Logged out successfully" in res.stdout
+            assert not token_path.exists()
     finally:
         auth_instance._auth_token = old_token
         if token_path.exists():

--- a/tests/test_authflows.py
+++ b/tests/test_authflows.py
@@ -493,19 +493,17 @@ def test_logout_function(
 
     mocker.patch("webbrowser.open", return_value=True)
 
-    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
-    temp_f.close()
-
-    try:
+    with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
         with open(temp_f.name, 'w') as f:
             json.dump(mock_token_data(), f)
 
-        with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
-            logout(token_file=temp_f.name, host=test_server)
-        assert not os.path.exists(temp_f.name)
-    finally:
-        if os.path.exists(temp_f.name):
-            os.unlink(temp_f.name)
+        try:
+            with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
+                logout(token_file=temp_f.name, host=test_server)
+            assert not os.path.exists(temp_f.name)
+        finally:
+            if os.path.exists(temp_f.name):
+                os.unlink(temp_f.name)
 
 
 def test_auth_logout_method(
@@ -517,21 +515,20 @@ def test_auth_logout_method(
 
     old_token = deepcopy(auth_instance._auth_token)
 
-    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
-    temp_f.close()
-
     try:
-        with open(temp_f.name, 'w') as f:
-            json.dump(mock_token_data(), f)
-        auth_instance._auth_token = mock_token_data()
+        with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
+            with open(temp_f.name, 'w') as f:
+                json.dump(mock_token_data(), f)
+            auth_instance._auth_token = mock_token_data()
 
-        auth_instance.token_file = temp_f.name
-        with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
-            auth_instance._logout(host=test_server)
+            auth_instance.token_file = temp_f.name
+            with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
+                auth_instance._logout(host=test_server)
 
-        assert auth_instance._auth_token is None
-        assert not os.path.exists(temp_f.name)
+            assert auth_instance._auth_token is None
+            assert not os.path.exists(temp_f.name)
     finally:
         auth_instance._auth_token = old_token
         if os.path.exists(temp_f.name):
             os.unlink(temp_f.name)
+

--- a/tests/test_authflows.py
+++ b/tests/test_authflows.py
@@ -493,17 +493,19 @@ def test_logout_function(
 
     mocker.patch("webbrowser.open", return_value=True)
 
-    with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
+    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
+    temp_f.close()
+
+    try:
         with open(temp_f.name, 'w') as f:
             json.dump(mock_token_data(), f)
 
-        try:
-            with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
-                logout(token_file=temp_f.name, host=test_server)
-            assert not os.path.exists(temp_f.name)
-        finally:
-            if os.path.exists(temp_f.name):
-                os.unlink(temp_f.name)
+        with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
+            logout(token_file=temp_f.name, host=test_server)
+        assert not os.path.exists(temp_f.name)
+    finally:
+        if os.path.exists(temp_f.name):
+            os.unlink(temp_f.name)
 
 
 def test_auth_logout_method(
@@ -515,20 +517,21 @@ def test_auth_logout_method(
 
     old_token = deepcopy(auth_instance._auth_token)
 
+    temp_f = NamedTemporaryFile(suffix=".json", delete=False)
+    temp_f.close()
+
     try:
-        with NamedTemporaryFile(suffix=".json", delete=False) as temp_f:
-            with open(temp_f.name, 'w') as f:
-                json.dump(mock_token_data(), f)
-            auth_instance._auth_token = mock_token_data()
+        with open(temp_f.name, 'w') as f:
+            json.dump(mock_token_data(), f)
+        auth_instance._auth_token = mock_token_data()
 
-            auth_instance.token_file = temp_f.name
-            with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
-                auth_instance._logout(host=test_server)
+        auth_instance.token_file = temp_f.name
+        with patch.dict(os.environ, {"BROWSER_SESSION": "1"}, clear=False):
+            auth_instance._logout(host=test_server)
 
-            assert auth_instance._auth_token is None
-            assert not os.path.exists(temp_f.name)
+        assert auth_instance._auth_token is None
+        assert not os.path.exists(temp_f.name)
     finally:
         auth_instance._auth_token = old_token
         if os.path.exists(temp_f.name):
             os.unlink(temp_f.name)
-


### PR DESCRIPTION
Following up on the discussion in [the server-side logout endpoint PR](https://github.com/freva-org/freva-nextgen/pull/242#issuecomment-3442141999), this PR adds support for cleaning up both the local token file and the corresponding session on the OIDC server.
This was ready by the end of last week, I just forgot to push it earlier.

Main changes:

* we replaced

  ```bash
  freva-client auth
  ```

  with

  ```bash
  freva-client auth login
  ```
* And added

  ```bash
  freva-client auth logout
  ```

Since the latest REST API is already deployed on gems, you can test it with:

```bash
pip install git+https://github.com/freva-org/freva-nextgen.git@logout-client#subdirectory=freva-client
freva-client auth login --host https://www.gems.dkrz.de
freva-client auth logout --host https://www.gems.dkrz.de
```

Or in Python:

```python
from freva_client import authenticate, logout
authenticate(host="https://www.gems.dkrz.de")
logout(host="https://www.gems.dkrz.de")
```

