### PR TITLE
Fix: when it begins, if key doesn't exist yet, job is queued (3), not gone (5)

### DIFF
--- a/freva-rest/src/freva_rest/freva_data_portal/utils.py
+++ b/freva-rest/src/freva_rest/freva_data_portal/utils.py
@@ -166,8 +166,10 @@ async def read_redis_data(
         timeout += 1
     npolls = 0.0
     dt = 0.5
-    data = cloudpickle.loads((await Cache.get(key)) or b"\x80\x05}\x94.")
-    task_status = LoadStatus(data.get("status", 5))
+    raw = await Cache.get(key)
+    data = cloudpickle.loads(raw or b"\x80\x05}\x94.")
+    # If key doesn't exist yet, job is waiting (3), not gone (5)
+    task_status = LoadStatus(data.get("status", 3 if not raw else 5))
     while task_status.value > 2:
         npolls += dt
         await asyncio.sleep(dt)


### PR DESCRIPTION
When `/html` is fired, the very first `/status` poll almost always wins the race against the worker's initial Redis write. The key doesn't exist yet, so the cache returns empty, and the backend defaults to `5` (gone). when in reality the job was just submitted. This returned `5` disappears within a second once the worker writes its first entry. On a small change, this PR is going to return 3 status, when the `Cache.get(key)` is still empty. Do you think if this makes sense?