### PR TITLE
feat: Add flavour concept into STACAPI and enrich the collection via an static core in Solr

### DIFF
--- a/dev-env/create_cores.sh
+++ b/dev-env/create_cores.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-for this_core in  $CORE latest;do
-    if [ ! -d "/var/solr/data/$this_core" ];then
+for this_core in $CORE latest; do
+    if [ ! -d "/var/solr/data/$this_core" ]; then
         precreate-core $this_core
-        rm -rf /var/solr/data/$this_core/conf/synonyms.txt
-        ln -s /opt/solr/synonyms.txt /var/solr/data/$this_core/conf/synonyms.txt
-        cp /opt/solr/managed-schema.xml /var/solr/data/$this_core/conf/
     fi
+    cp /opt/solr/managed-schema.xml /var/solr/data/$this_core/conf/managed-schema.xml
+    rm -rf /var/solr/data/$this_core/conf/synonyms.txt
+    ln -s /opt/solr/synonyms.txt /var/solr/data/$this_core/conf/synonyms.txt
 done
+
+# Create the static core
+if [ ! -d "/var/solr/data/static" ]; then
+    precreate-core static
+fi
+cp /opt/solr/static-managed-schema.xml /var/solr/data/static/conf/managed-schema.xml

--- a/dev-env/docker-compose.yaml
+++ b/dev-env/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./config/solr/managed-schema.xml:/opt/solr/managed-schema.xml:ro
       - ./config/solr/synonyms.txt:/opt/solr/synonyms.txt:ro
+      - ./static-managed-schema.xml:/opt/solr/static-managed-schema.xml:ro
       - ./create_cores.sh:/docker-entrypoint-initdb.d/create_cores.sh:ro
     hostname: solr
     command: ["solr-foreground", "--user-managed"]

--- a/dev-env/static-managed-schema.xml
+++ b/dev-env/static-managed-schema.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema name="static" version="1.6">
+  <uniqueKey>id</uniqueKey>
+
+  <!-- Standard Solr field types required by the default configset -->
+  <fieldType name="binary"      class="solr.BinaryField"/>
+  <fieldType name="boolean"     class="solr.BoolField"        sortMissingLast="true"/>
+  <fieldType name="booleans"    class="solr.BoolField"        sortMissingLast="true" multiValued="true"/>
+  <fieldType name="pint"        class="solr.IntPointField"    docValues="true"/>
+  <fieldType name="pints"       class="solr.IntPointField"    docValues="true" multiValued="true"/>
+  <fieldType name="plong"       class="solr.LongPointField"   docValues="true"/>
+  <fieldType name="plongs"      class="solr.LongPointField"   docValues="true" multiValued="true"/>
+  <fieldType name="pfloat"      class="solr.FloatPointField"  docValues="true"/>
+  <fieldType name="pfloats"     class="solr.FloatPointField"  docValues="true" multiValued="true"/>
+  <fieldType name="pdouble"     class="solr.DoublePointField" docValues="true"/>
+  <fieldType name="pdoubles"    class="solr.DoublePointField" docValues="true" multiValued="true"/>
+  <fieldType name="pdate"       class="solr.DatePointField"   docValues="true"/>
+  <fieldType name="pdates"      class="solr.DatePointField"   docValues="true" multiValued="true"/>
+  <fieldType name="string"      class="solr.StrField"         sortMissingLast="true"/>
+  <fieldType name="strings"     class="solr.StrField"         sortMissingLast="true" multiValued="true"/>
+  <fieldType name="text_general" class="solr.TextField"       positionIncrementGap="100">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- System fields -->
+  <field name="_version_"        type="plong"        indexed="true"  stored="true"/>
+  <field name="_root_"           type="string"       indexed="true"  stored="false" docValues="false"/>
+
+  <!-- Primary key -->
+  <field name="id"               type="string"       indexed="true"  stored="true" required="true"/>
+
+  <!-- Static metadata -->
+  <field name="title"            type="string"       indexed="true"  stored="true"/>
+  <field name="description"      type="text_general" indexed="true"  stored="true"/>
+  <field name="license"          type="string"       indexed="false" stored="true"/>
+  <field name="license_url"      type="string"       indexed="false" stored="true"/>
+  <field name="keywords"         type="strings"      indexed="true"  stored="true" multiValued="true"/>
+  <field name="thumbnail_url"    type="string"       indexed="false" stored="true"/>
+  <field name="thumbnail_type"   type="string"       indexed="false" stored="true"/>
+  <field name="documentation_url" type="string"      indexed="false" stored="true"/>
+  <field name="spatial_bbox"     type="pdoubles"     indexed="false" stored="true" multiValued="true"/>
+  <field name="temporal_start"   type="pdate"        indexed="false" stored="true"/>
+  <field name="temporal_end"     type="pdate"        indexed="false" stored="true"/>
+</schema>

--- a/freva-client/pyproject.toml
+++ b/freva-client/pyproject.toml
@@ -45,7 +45,7 @@ Source = "https://github.com/freva-org/freva-nextgen/"
 
 [project.optional-dependencies]
 dev = ["tox"]
-tests = ["namegenerator"]
+tests = []
 
 [tool.flit.sdist]
 include = ["assets/*"]

--- a/freva-rest/src/freva_rest/cli.py
+++ b/freva-rest/src/freva_rest/cli.py
@@ -291,10 +291,11 @@ def cli(argv: Optional[List[str]] = None) -> None:
                 defaults.setdefault(f"API_{name}", str(value or ""))
     defaults = {k: v for k, v in defaults.items() if v}
     if args.dev:
-        from freva_rest.databrowser_api.mock import read_data
+        from freva_rest.databrowser_api.mock import read_data, read_static
 
         for core in cfg.solr_cores:
             asyncio.run(read_data(core, cfg.solr_url))
+        asyncio.run(read_static(cfg.solr_url))
     workers = {False: args.n_workers, True: None}
     logging_config = deepcopy(LOGGING_CONFIG)
     level = {

--- a/freva-rest/src/freva_rest/databrowser_api/mock/__init__.py
+++ b/freva-rest/src/freva_rest/databrowser_api/mock/__init__.py
@@ -21,3 +21,12 @@ async def read_data(core: str, uri: str) -> None:
                 await asyncio.sleep(1)
             else:
                 raise
+
+
+async def read_static(uri: str) -> None:
+    """Seed the static core"""
+    try:
+        await read_data("static", uri)
+    except httpx.HTTPStatusError as e:  # pragma: no cover
+        if e.response.status_code not in (404, 405):
+            raise

--- a/freva-rest/src/freva_rest/databrowser_api/mock/static.json
+++ b/freva-rest/src/freva_rest/databrowser_api/mock/static.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "cmip6",
+    "title": "CMIP6: Coupled Model Intercomparison Project Phase 6",
+    "description": "Multi-model ensemble of global climate simulations produced under the Coupled Model Intercomparison Project Phase 6 (CMIP6). Covers historical and future scenario experiments across a wide range of models and institutions.",
+    "license": "CC-BY-4.0",
+    "license_url": "https://creativecommons.org/licenses/by/4.0/",
+    "keywords": ["cmip6", "climate", "scenarios", "global", "atmosphere", "ocean"],
+    "thumbnail_url": "https://s3.eu-dkrz-1.dkrz.cloud/freva/static_thumbnails/cmip.png",
+    "thumbnail_type": "image/png",
+    "documentation_url": "https://pcmdi.llnl.gov/CMIP6/",
+    "spatial_bbox": [-180.0, -90.0, 180.0, 90.0],
+    "temporal_start": "1850-01-01T00:00:00Z",
+    "temporal_end": "2100-12-31T23:59:59Z"
+  },
+  {
+    "id": "nextgems",
+    "title": "nextGEMS: Next Generation Earth Modelling Systems",
+    "description": "High-resolution global coupled climate simulations produced under the nextGEMS project. Features kilometre-scale atmosphere and ocean models enabling detailed representation of storms, ocean eddies, and other fine-scale processes.",
+    "license": "CC-BY-4.0",
+    "license_url": "https://creativecommons.org/licenses/by/4.0/",
+    "keywords": ["nextgems", "high-resolution", "climate", "global", "atmosphere", "ocean"],
+    "thumbnail_url": "https://s3.eu-dkrz-1.dkrz.cloud/freva/static_thumbnails/nextgems.png",
+    "thumbnail_type": "image/png",
+    "documentation_url": "https://nextgems-h2020.eu/",
+    "spatial_bbox": [-180.0, -90.0, 180.0, 90.0],
+    "temporal_start": "1850-01-01T00:00:00Z",
+    "temporal_end": "2100-12-31T23:59:59Z"
+  },
+  {
+    "id": "cordex",
+    "title": "CORDEX: Coordinated Regional Climate Downscaling Experiment",
+    "description": "High-resolution regional climate model simulations produced under the Coordinated Regional Climate Downscaling Experiment (CORDEX). Provides dynamically downscaled projections for multiple domains worldwide.",
+    "license": "CC-BY-4.0",
+    "license_url": "https://creativecommons.org/licenses/by/4.0/",
+    "keywords": ["cordex", "regional", "downscaling", "climate", "rcm"],
+    "thumbnail_url": "https://s3.eu-dkrz-1.dkrz.cloud/freva/static_thumbnails/cordex.jpg",
+    "thumbnail_type": "image/jpeg",
+    "documentation_url": "https://cordex.org/",
+    "spatial_bbox": [-180.0, -90.0, 180.0, 90.0],
+    "temporal_start": "1950-01-01T00:00:00Z",
+    "temporal_end": "2100-12-31T23:59:59Z"
+  },
+  {
+    "id": "observations",
+    "title": "Observations: Gridded Observational Datasets",
+    "description": "Collection of gridded observational and reanalysis datasets used as reference data for model evaluation and bias correction.",
+    "license": "proprietary",
+    "license_url": "",
+    "keywords": ["observations", "reanalysis", "reference", "evaluation"],
+    "thumbnail_url": "https://s3.eu-dkrz-1.dkrz.cloud/freva/static_thumbnails/observations.png",
+    "thumbnail_type": "image/png",
+    "documentation_url": "",
+    "spatial_bbox": [-180.0, -90.0, 180.0, 90.0],
+    "temporal_start": "1900-01-01T00:00:00Z",
+    "temporal_end": null
+  }
+]

--- a/freva-rest/src/freva_rest/stac_api/core.py
+++ b/freva-rest/src/freva_rest/stac_api/core.py
@@ -14,11 +14,13 @@ from typing import (
 )
 from urllib.parse import urlencode
 
+import httpx
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
 from freva_rest.config import ServerConfig
 from freva_rest.databrowser_api import Solr
+from freva_rest.databrowser_api.services import Flavour
 from freva_rest.logger import logger
 from freva_rest.utils.stac_utils import (
     Asset,
@@ -33,6 +35,7 @@ from freva_rest.utils.stats_utils import store_api_statistics
 from .schema import (
     CONFORMANCE_URLS,
     STAC_VERSION,
+    STACAsset,
     STACCollection,
     STACExtent,
     STACLinks,
@@ -54,14 +57,24 @@ class STACAPI:
         self,
         config: ServerConfig,
         *,
+        flavour: str = "freva",
         limit: int = 12,
         token: Optional[str] = None,
         datetime: Optional[str] = None,
         bbox: Optional[str] = None,
         uniuq_key: Literal["file", "uri"] = "file",
+        _translator: Any = None,
         **query: list[str],
     ) -> None:
         self.config = config
+        self.flavour = flavour
+        self.base_url = f"{config.proxy}/api/freva-nextgen/stacapi/{flavour}"
+        self.translator = _translator
+        self.reverse_lookup: Dict[str, str] = (
+            {v: k for k, v in _translator.forward_lookup.items()}
+            if _translator is not None
+            else {}
+        )
         self.uniq_key = uniuq_key
         self.solr_object = Solr(config, multi_version=False)
         self.stacapi_query = query
@@ -76,6 +89,7 @@ class STACAPI:
         cls,
         config: ServerConfig,
         *,
+        flavour: str = "freva",
         limit: int = 12,
         token: Optional[str] = None,
         datetime: Optional[str] = None,
@@ -89,6 +103,8 @@ class STACAPI:
         ----------
         config : ServerConfig
             Server configuration object.
+        flavour : str, optional
+            The DRS flavour to use for facet name translation.
         limit : int, optional
             Limit for the number of items to return.
         token : str, optional
@@ -117,13 +133,19 @@ class STACAPI:
                     status_code=422, detail="Could not validate input."
                 )
 
+        translator = await Flavour.validate_and_get_flavour(
+            config, flavour, user_name=None
+        )
+
         return cls(
             config=config,
+            flavour=flavour,
             limit=limit,
             token=token,
             datetime=datetime,
             bbox=bbox,
             uniuq_key=uniuq_key,
+            _translator=translator,
             **query,
         )
 
@@ -205,15 +227,14 @@ class STACAPI:
             "links": [
                 {
                     "rel": "self",
-                    "href": self.config.proxy + "/api/freva-nextgen/stacapi",
+                    "href": self.base_url,
                     "type": "application/json",
                     "title": "Landing Page",
                 },
                 {
                     "rel": "conformance",
                     "href": (
-                        self.config.proxy
-                        + "/api/freva-nextgen/stacapi/conformance"
+                        self.base_url + "/conformance"
                     ),
                     "type": "application/json",
                     "title": "Conformance Classes",
@@ -221,24 +242,21 @@ class STACAPI:
                 {
                     "rel": "data",
                     "href": (
-                        self.config.proxy
-                        + "/api/freva-nextgen/stacapi/collections"
+                        self.base_url + "/collections"
                     ),
                     "type": "application/json",
                     "title": "Data Collections",
                 },
                 {
                     "rel": "search",
-                    "href": self.config.proxy
-                    + "/api/freva-nextgen/stacapi/search",
+                    "href": self.base_url + "/search",
                     "type": "application/geo+json",
                     "title": "STAC search",
                     "method": "POST",
                 },
                 {
                     "rel": "search",
-                    "href": self.config.proxy
-                    + "/api/freva-nextgen/stacapi/search",
+                    "href": self.base_url + "/search",
                     "type": "application/geo+json",
                     "title": "STAC search",
                     "method": "GET",
@@ -247,8 +265,7 @@ class STACAPI:
                     "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
                     "type": "application/schema+json",
                     "title": "Queryables",
-                    "href": self.config.proxy
-                    + "/api/freva-nextgen/stacapi/queryables",
+                    "href": self.base_url + "/queryables",
                     "method": "GET",
                 },
                 {
@@ -274,116 +291,196 @@ class STACAPI:
                     {
                         "rel": "child",
                         "href": (
-                            self.config.proxy
-                            + "/api/freva-nextgen/stacapi/collections/"
-                            + collection_id
+                            self.base_url + "/collections/" + collection_id
                         ),
                         "type": "application/json",
                     }
                 )
         return response
 
+    # TODO: For time being this function stays here, but in the
+    # future we should consider to move it to search class
+    async def _fetch_collection_static_metadata(
+        self, collection_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Query the static Solr core for static collection metadata.
+
+        It returns None on any error or if the core / document doesn't exist,
+        which causes get_collection() to fall back to the current defaults
+        to ensure backwards compatibility.
+        """
+        url = (
+            self.config.get_core_url("static") + "/select"
+        )
+        params = {
+            "q": f'id:"{collection_id}"',
+            "rows": "1",
+            "wt": "json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(5)) as client:
+                response = await client.get(url, params=params)
+                response.raise_for_status()
+                docs = response.json().get("response", {}).get("docs", [])
+                return docs[0] if docs else None
+        except Exception as exc:  # pragma: no cover
+            logger.debug(
+                "static core not available or no doc for %s: %s",
+                collection_id,
+                exc,
+            )
+            return None
+
     async def get_collection(self, collection_id: str) -> STACCollection:
         """Get a specific collection."""
-        # TODO: We need to define a new core in Solr which contains the
-        # description of each collection and all other metadata we need
-        # for constructing this. For time being we define them all as
-        # constants, since we don't have any usecase for this yet.
-        # TODO: We need to add assets to the collections
         collection_id = collection_id.lower()
         collection_ids = await self.get_all_project_facets()
         if collection_id not in collection_ids:
             raise HTTPException(
                 status_code=404, detail=f"Collection {collection_id} not found"
             )
+
+        static = await self._fetch_collection_static_metadata(collection_id)
+
+        title = (static or {}).get("title") or collection_id.upper()
+        description = (
+            (static or {}).get("description")
+            or f"Collection {collection_id.upper()}"
+        )
+        license_id = (static or {}).get("license") or "proprietary"
+        license_url = (
+            (static or {}).get("license_url")
+            or "https://opensource.org/license/bsd-3-clause"
+        )
+        keywords = (
+            (static or {}).get("keywords")
+            or [collection_id, "climate", "analysis", "freva"]
+        )
+
+        raw_bbox = (static or {}).get("spatial_bbox")
+        if raw_bbox and len(raw_bbox) == 4:
+            spatial_bbox = [list(raw_bbox)]
+        else:
+            spatial_bbox = [[-180, -90, 180, 90]]
+
+        temporal_start = (static or {}).get("temporal_start") or None
+        temporal_end = (static or {}).get("temporal_end") or None
+
+        assets: Optional[Dict[str, STACAsset]] = None
+        thumbnail_url = (static or {}).get("thumbnail_url")
+        documentation_url = (static or {}).get("documentation_url")
+        collection_self_url = self.base_url + "/collections/" + collection_id
+        assets = {
+            "metadata": STACAsset(
+                href=collection_self_url,
+                title="Collection Metadata",
+                description="Machine-readable STAC collection metadata.",
+                type="application/json",
+                roles=["metadata"],
+            )
+        }
+        if thumbnail_url:
+            thumbnail_type = (static or {}).get("thumbnail_type") or "image/png"
+            assets["thumbnail"] = STACAsset(
+                href=thumbnail_url,
+                title=f"{title} thumbnail",
+                description=f"Preview thumbnail for collection {title}.",
+                type=thumbnail_type,
+                roles=["thumbnail"],
+            )
+        if documentation_url:
+            assets["documentation"] = STACAsset(
+                href=documentation_url,
+                title=f"{title} documentation",
+                description=f"Documentation or DOI landing page for {title}.",
+                type="text/html",
+                roles=["overview"],
+            )
+
+        links = [
+            STACLinks(
+                rel="self",
+                href=collection_self_url,
+                type="application/json",
+                title="Collection",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+            STACLinks(
+                rel="parent",
+                href=self.base_url + "/",
+                type="application/json",
+                title="Landing Page",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+            STACLinks(
+                rel="root",
+                href=self.base_url + "/",
+                type="application/json",
+                title="Root",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+            STACLinks(
+                rel="items",
+                href=collection_self_url + "/items",
+                type="application/geo+json",
+                title="Items",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+            STACLinks(
+                rel="queryables",
+                href=collection_self_url + "/queryables",
+                type="application/schema+json",
+                title="Queryables",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+            STACLinks(
+                rel="license",
+                href=license_url,
+                title="License",
+                type="text/html",
+                method="GET",
+                merge=True,
+                body=None,
+            ),
+        ]
+
+        if thumbnail_url:
+            links.append(
+                STACLinks(
+                    rel="preview",
+                    href=thumbnail_url,
+                    type=(static or {}).get("thumbnail_type") or "image/png",
+                    title=f"{title} preview",
+                    method="GET",
+                    merge=False,
+                    body=None,
+                )
+            )
+
         return STACCollection(
             id=collection_id,
             type="Collection",
             stac_version="1.1.0",
-            title=collection_id.upper(),
-            description=f"Collection {collection_id.upper()}",
-            license="proprietary",
+            title=title,
+            description=description,
+            license=license_id,
             summaries=None,
-            # TODO: we need to take care of extend somehow
-            # it seems with None it's still valid
             extent=STACExtent(
-                spatial={"bbox": [[-180, -90, 180, 90]]},
-                temporal={"interval": [[None, None]]},
+                spatial={"bbox": spatial_bbox},
+                temporal={"interval": [[temporal_start, temporal_end]]},
             ),
-            links=[
-                STACLinks(
-                    rel="self",
-                    href=(
-                        self.config.proxy
-                        + "/api/freva-nextgen/stacapi"
-                        + "/collections/"
-                        + collection_id
-                    ),
-                    type="application/json",
-                    title="Collection",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-                STACLinks(
-                    rel="parent",
-                    href=self.config.proxy + "/api/freva-nextgen/stacapi/",
-                    type="application/json",
-                    title="Landing Page",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-                STACLinks(
-                    rel="root",
-                    href=self.config.proxy + "/api/freva-nextgen/stacapi/",
-                    type="application/json",
-                    title="Root",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-                STACLinks(
-                    rel="items",
-                    href=(
-                        self.config.proxy
-                        + "/api/freva-nextgen/stacapi"
-                        + "/collections/"
-                        + collection_id
-                        + "/items"
-                    ),
-                    type="application/geo+json",
-                    title="Items",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-                STACLinks(
-                    rel="queryables",
-                    href=(
-                        self.config.proxy
-                        + "/api/freva-nextgen/stacapi"
-                        + "/collections/"
-                        + collection_id
-                        + "/queryables"
-                    ),
-                    type="application/schema+json",
-                    title="Queryables",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-                STACLinks(
-                    rel="license",
-                    href="https://opensource.org/license/bsd-3-clause",
-                    title="BSD 3-Clause 'New' or 'Revised' License",
-                    type="text/html",
-                    method="GET",
-                    merge=True,
-                    body=None,
-                ),
-            ],
-            keywords=[collection_id, "climate", "analysis", "freva"],
+            links=links,
+            keywords=keywords,
             providers=[
                 STACProvider(
                     name="Freva",
@@ -392,10 +489,10 @@ class STACAPI:
                         "evaluation, providing access to various datasets and tools."
                     ),
                     roles=["producer", "processor", "host"],
-                    url=self.config.proxy + "/api/freva-nextgen/stacapi",
+                    url=self.base_url,
                 )
             ],
-            assets=None,
+            assets=assets,
         )
 
     async def get_collections(self) -> AsyncGenerator[str, None]:
@@ -414,7 +511,7 @@ class STACAPI:
         links = [
             STACLinks(
                 rel="self",
-                href=f"{self.config.proxy}/api/freva-nextgen/stacapi/collections",
+                href=f"{self.base_url}/collections",
                 type="application/json",
                 title="Collections",
                 method="GET",
@@ -423,7 +520,7 @@ class STACAPI:
             ),
             STACLinks(
                 rel="parent",
-                href=f"{self.config.proxy}/api/freva-nextgen/stacapi",
+                href=self.base_url,
                 type="application/json",
                 title="Landing Page",
                 method="GET",
@@ -432,7 +529,7 @@ class STACAPI:
             ),
             STACLinks(
                 rel="root",
-                href=f"{self.config.proxy}/api/freva-nextgen/stacapi",
+                href=self.base_url,
                 type="application/json",
                 title="Root",
                 method="GET",
@@ -526,7 +623,11 @@ class STACAPI:
 
         properties = {
             **{
-                k: result.get(k)
+                (
+                    self.translator.forward_lookup.get(k, k)
+                    if self.translator is not None
+                    else k
+                ): result.get(k)
                 for k in self.config.solr_fields
                 if k in result and result.get(k) is not None
             },
@@ -543,7 +644,7 @@ class STACAPI:
             item.properties["start_datetime"] = start_time.isoformat() + "Z"
             item.properties["end_datetime"] = end_time.isoformat() + "Z"
             item.properties["datetime"] = start_time.isoformat() + "Z"
-        base_url = f"{self.config.proxy}/api/freva-nextgen/stacapi"
+        base_url = self.base_url
         links_to_add = [
             {
                 "rel": "self",
@@ -818,8 +919,7 @@ class STACAPI:
         if bbox:
             base_params["bbox"] = bbox
         base_url = (
-            f"{self.config.proxy}/api/freva-nextgen/"
-            f"stacapi/collections/{collection_id}/items"
+            f"{self.base_url}/collections/{collection_id}/items"
         )
 
         filters = [f"project:{collection_id}"]
@@ -926,7 +1026,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     # special mappings - collection and id are non-changeable
                     if field == "collection":
                         field = "project"
@@ -950,7 +1050,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"
                     elif field == "id":
@@ -972,7 +1072,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"
                     return [f"{field}:{{* TO {value}}}"]
@@ -983,7 +1083,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"
                     return [f"{field}:[* TO {value}]"]
@@ -994,7 +1094,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"
                     return [f"{field}:{{{value} TO *}}"]
@@ -1005,7 +1105,7 @@ class STACAPI:
                 prop = args[0]
                 value = args[1]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"
                     return [f"{field}:[{value} TO *]"]
@@ -1015,7 +1115,7 @@ class STACAPI:
             if len(args) == 1:
                 prop = args[0]
                 if isinstance(prop, dict) and prop.get("property"):
-                    field = prop["property"]
+                    field = self.reverse_lookup.get(prop["property"], prop["property"])
                     if field == "collection":
                         field = "project"  # pragma: no cover
                     return [f"-{field}:[* TO *]"]
@@ -1105,7 +1205,7 @@ class STACAPI:
         if q:
             q_terms = [term.strip() for term in q.split(",") if term.strip()]
 
-        base_url = f"{self.config.proxy}/api/freva-nextgen/stacapi/search"
+        base_url = f"{self.base_url}/search"
         base_params: Dict[str, Any] = {"limit": limit}
         if collections:
             base_params["collections"] = collections
@@ -1297,16 +1397,21 @@ class STACAPI:
         # Fetch dynamic facets and add them as properties
         facets = await self._fetch_facets()
         for facet_name, facet_values in facets.items():
-            if facet_name not in properties:
-                properties[facet_name] = {
-                    "description": f"Search facet: {facet_name}",
+            translated = (
+                self.translator.forward_lookup.get(facet_name, facet_name)
+                if self.translator is not None
+                else facet_name
+            )
+            if translated not in properties:
+                properties[translated] = {
+                    "description": f"Search facet: {translated}",
                     "type": "string",
                     "enum": facet_values,
                 }
 
         queryables_schema = {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
-            "$id": f"{self.config.proxy}/api/freva-nextgen/stacapi/queryables",
+            "$id": f"{self.base_url}/queryables",
             "type": "object",
             "title": "Queryables for Freva STAC-API",
             "description": (
@@ -1336,8 +1441,7 @@ class STACAPI:
         collection_queryables.update(
             {
                 "$id": (
-                    f"{self.config.proxy}/api/freva-nextgen/"
-                    f"stacapi/collections/{collection_id}/queryables"
+                    f"{self.base_url}/collections/{collection_id}/queryables"
                 ),
                 "title": f"Queryables for Collection {collection_id}",
                 "description": (

--- a/freva-rest/src/freva_rest/stac_api/endpoints.py
+++ b/freva-rest/src/freva_rest/stac_api/endpoints.py
@@ -28,14 +28,14 @@ from .schema import (
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/",
+    "/api/freva-nextgen/stacapi/{flavour}/",
     tags=["STAC API"],
     status_code=200,
     response_model=LandingPageResponse,
     responses={503: {"description": "Search backend error"}},
     response_class=JSONResponse,
 )
-async def landing_page() -> JSONResponse:
+async def landing_page(flavour: str = "freva") -> JSONResponse:
     """STAC API landing page declaration.
 
     This endpoint provides the landing page of the STAC API,
@@ -43,22 +43,29 @@ async def landing_page() -> JSONResponse:
     description, and links to collections and other resources.
     The landing page serves as an entry point for users to
     explore the available collections and items in the STAC API.
+
+    The ``flavour`` path parameter selects the DRS standard used to name
+    facets inside STAC items (e.g. ``freva``, ``cmip6``, ``cmip5``,
+    ``cordex``).  Custom flavours added by an administrator are also
+    accepted.
     """
-    stac_instance = STACAPI(server_config)
+    stac_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     await stac_instance.store_results(0, 200, "landing_page", {})
     response = await stac_instance.get_landing_page()
     return JSONResponse(response)
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/conformance",
+    "/api/freva-nextgen/stacapi/{flavour}/conformance",
     tags=["STAC API"],
     status_code=200,
     response_model=ConformanceResponse,
     responses={503: {"description": "Search backend error"}},
     response_class=JSONResponse,
 )
-async def conformance() -> JSONResponse:
+async def conformance(flavour: str = "freva") -> JSONResponse:
     """STAC API conformance declaration.
 
     This endpoint returns the conformance classes that the STAC API
@@ -70,22 +77,24 @@ async def conformance() -> JSONResponse:
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/collections",
+    "/api/freva-nextgen/stacapi/{flavour}/collections",
     tags=["STAC API"],
     status_code=200,
     response_model=CollectionsResponse,
     responses={503: {"description": "Search backend error"}},
     response_class=PlainTextResponse,
 )
-async def collections() -> StreamingResponse:
+async def collections(flavour: str = "freva") -> StreamingResponse:
     """List all collections in the STAC API.
 
-    This endpoint retrieves a list of all collections available in the STAC API.
     Each collection represents a group of related items and provides metadata
     about the collection, including its ID, title, description, and spatial
-    and temporal extents.
+    and temporal extents.  Item properties inside each collection are named
+    according to the chosen ``flavour``.
     """
-    stacapi_instance = STACAPI(server_config)
+    stacapi_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     await stacapi_instance.store_results(0, 200, "collections", {})
     return StreamingResponse(
         stacapi_instance.get_collections(),
@@ -94,7 +103,7 @@ async def collections() -> StreamingResponse:
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/collections/{collection_id}",
+    "/api/freva-nextgen/stacapi/{flavour}/collections/{collection_id}",
     tags=["STAC API"],
     status_code=200,
     response_model=STACCollection,
@@ -104,24 +113,30 @@ async def collections() -> StreamingResponse:
     },
     response_class=JSONResponse,
 )
-async def collection(collection_id: str) -> JSONResponse:
+async def collection(
+    collection_id: str,
+    flavour: str = "freva",
+) -> JSONResponse:
     """Get a specific collection.
 
-    This endpoint retrieves a specific collection from the STAC API.
-    The collection is identified by its ID.
+    The collection is identified by its ID.  Item property names within the
+    collection are presented in the chosen ``flavour``'s DRS vocabulary.
     """
-    stacapi_instance = STACAPI(server_config)
+    stacapi_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     await stacapi_instance.store_results(
         0, 200, "collection", {"collection_id": collection_id}
     )
-    collection = await stacapi_instance.get_collection(collection_id)
+    collection_obj = await stacapi_instance.get_collection(collection_id)
     return JSONResponse(
-        collection.model_dump(exclude_none=True), media_type="application/json"
+        collection_obj.model_dump(exclude_none=True),
+        media_type="application/json",
     )
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/collections/{collection_id}/items",
+    "/api/freva-nextgen/stacapi/{flavour}/collections/{collection_id}/items",
     tags=["STAC API"],
     status_code=200,
     response_model=ItemCollectionResponse,
@@ -134,6 +149,7 @@ async def collection(collection_id: str) -> JSONResponse:
 async def collection_items(
     request: Request,
     collection_id: str,
+    flavour: str = "freva",
     limit: int = Query(10, ge=1, le=1000),
     token: Optional[str] = Query(
         None,
@@ -173,12 +189,13 @@ async def collection_items(
 ) -> StreamingResponse:
     """Get items from a specific collection.
 
-    This endpoint retrieves items from a specific collection in the STAC API.
-    The collection is identified by its ID, and the items can be filtered
-    using various query parameters such as limit, token, datetime, and bbox.
+    Items can be filtered using various query parameters such as ``limit``,
+    ``token``, ``datetime``, and ``bbox``.  Each item's properties are named
+    according to the chosen ``flavour``'s DRS vocabulary.
     """
     stac_instance = await STACAPI.validate_parameters(
         config=server_config,
+        flavour=flavour,
         limit=limit,
         token=token,
         datetime=datetime,
@@ -188,6 +205,7 @@ async def collection_items(
     )
     query_params = {
         "collection_id": collection_id,
+        "flavour": flavour,
         "limit": limit,
         "token": token,
         "datetime": datetime,
@@ -203,7 +221,7 @@ async def collection_items(
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/collections/{collection_id}/items/{item_id}",
+    "/api/freva-nextgen/stacapi/{flavour}/collections/{collection_id}/items/{item_id}",
     tags=["STAC API"],
     status_code=200,
     response_model=STACItem,
@@ -216,18 +234,21 @@ async def collection_items(
 async def collection_item(
     collection_id: str,
     item_id: str,
+    flavour: str = "freva",
 ) -> JSONResponse:
     """Get a specific item from a collection.
 
-    This endpoint retrieves a specific item from a collection in the STAC API.
-    The collection is identified by its ID, and the item is identified by its ID.
+    The item's properties are presented in the chosen ``flavour``'s DRS
+    vocabulary (e.g. ``activity_id`` instead of ``project`` for cmip6).
     """
-    stac_instance = STACAPI(server_config)
+    stac_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     await stac_instance.store_results(
         0,
         200,
         "collection_item",
-        {"collection_id": collection_id, "item_id": item_id},
+        {"collection_id": collection_id, "item_id": item_id, "flavour": flavour},
     )
     item = await stac_instance.get_collection_item(collection_id, item_id)
     return JSONResponse(
@@ -237,7 +258,7 @@ async def collection_item(
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/search",
+    "/api/freva-nextgen/stacapi/{flavour}/search",
     tags=["STAC API"],
     status_code=200,
     response_model=ItemCollectionResponse,
@@ -249,6 +270,7 @@ async def collection_item(
 )
 async def search_get(
     request: Request,
+    flavour: str = "freva",
     collections: Optional[str] = Query(
         None,
         title="Collections",
@@ -326,11 +348,14 @@ async def search_get(
 ) -> StreamingResponse:
     """STAC API search endpoint (GET).
 
-    This endpoint allows searching across all collections using query parameters.
-    It supports spatial, temporal, and property-based filtering of STAC items.
+    This endpoint allows searching across all collections using query
+    parameters.  It supports spatial, temporal, and property-based filtering
+    of STAC items.  Item properties are returned using the chosen
+    ``flavour``'s DRS vocabulary.
     """
     stac_instance = await STACAPI.validate_parameters(
         config=server_config,
+        flavour=flavour,
         limit=limit,
         token=token,
         datetime=datetime,
@@ -339,6 +364,7 @@ async def search_get(
         **STACAPISchema.process_parameters(request),
     )
     query_params = {
+        "flavour": flavour,
         "collections": collections,
         "ids": ids,
         "bbox": bbox,
@@ -366,7 +392,7 @@ async def search_get(
 
 
 @app.post(
-    "/api/freva-nextgen/stacapi/search",
+    "/api/freva-nextgen/stacapi/{flavour}/search",
     tags=["STAC API"],
     status_code=200,
     response_model=ItemCollectionResponse,
@@ -378,12 +404,17 @@ async def search_get(
 )
 async def search_post(
     request: Request,
+    flavour: str = "freva",
     body: SearchPostRequest = Body(...),
 ) -> StreamingResponse:
-    """STAC API search endpoint (POST)"""
+    """STAC API search endpoint (POST).
 
+    Item properties in the response are returned under the chosen
+    ``flavour``'s DRS vocabulary.
+    """
     stac_instance = await STACAPI.validate_parameters(
         config=server_config,
+        flavour=flavour,
         limit=body.limit or 10,
         token=body.token,
         datetime=body.datetime,
@@ -393,6 +424,7 @@ async def search_post(
     )
 
     query_params = {
+        "flavour": flavour,
         "collections": body.collections,
         "ids": body.ids,
         "bbox": body.bbox,
@@ -407,7 +439,6 @@ async def search_post(
             collections=body.collections,
             ids=body.ids,
             bbox=body.bbox,
-            # intersects=body.intersects,
             datetime=body.datetime,
             limit=body.limit or 10,
             token=body.token,
@@ -422,27 +453,29 @@ async def search_post(
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/queryables",
+    "/api/freva-nextgen/stacapi/{flavour}/queryables",
     tags=["STAC API"],
     status_code=200,
     response_model=QueryablesResponse,
     responses={503: {"description": "Search backend error"}},
     response_class=JSONResponse,
 )
-async def queryables() -> JSONResponse:
+async def queryables(flavour: str = "freva") -> JSONResponse:
     """Global queryables endpoint.
 
-    This endpoint returns the queryables that can be used in filter expressions
-    across all collections. It returns a JSON Schema document describing the
-    available properties that can be used for filtering.
+    Returns the queryable properties that can be used in filter expressions
+    across all collections.  Property names are given in the chosen
+    ``flavour``'s DRS vocabulary.
     """
-    stac_instance = STACAPI(server_config)
+    stac_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     response = await stac_instance.get_queryables()
     return JSONResponse(response, media_type="application/schema+json")
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/collections/{collection_id}/queryables",
+    "/api/freva-nextgen/stacapi/{flavour}/collections/{collection_id}/queryables",
     tags=["STAC API"],
     status_code=200,
     response_model=QueryablesResponse,
@@ -452,27 +485,31 @@ async def queryables() -> JSONResponse:
     },
     response_class=JSONResponse,
 )
-async def collection_queryables(collection_id: str) -> JSONResponse:
+async def collection_queryables(
+    collection_id: str,
+    flavour: str = "freva",
+) -> JSONResponse:
     """Collection-specific queryables endpoint.
 
-    This endpoint returns the queryables that can be used in filter expressions
-    for a specific collection. It returns a JSON Schema document describing the
-    available properties that can be used for filtering within that collection.
+    Returns the queryable properties for a specific collection.  Property
+    names are given in the chosen ``flavour``'s DRS vocabulary.
     """
-    stac_instance = STACAPI(server_config)
+    stac_instance = await STACAPI.validate_parameters(
+        server_config, flavour=flavour
+    )
     response = await stac_instance.get_collection_queryables(collection_id)
     return JSONResponse(response, media_type="application/schema+json")
 
 
 @app.get(
-    "/api/freva-nextgen/stacapi/_mgmt/ping",
+    "/api/freva-nextgen/stacapi/{flavour}/_mgmt/ping",
     tags=["STAC API"],
     status_code=200,
     response_model=PingResponse,
     responses={200: {"description": "Successful Response"}},
     response_class=JSONResponse,
 )
-async def ping() -> JSONResponse:
+async def ping(flavour: str = "freva") -> JSONResponse:
     """
     Liveliness/readiness probe.
     """

--- a/freva-rest/src/freva_rest/stac_api/schema.py
+++ b/freva-rest/src/freva_rest/stac_api/schema.py
@@ -124,6 +124,16 @@ class ConformanceResponse(BaseModel):
     )
 
 
+class STACAsset(BaseModel):
+    """STAC Asset model for collection-level assets."""
+
+    href: str = Field(..., description="Asset URL")
+    title: Optional[str] = Field(None, description="Asset title")
+    description: Optional[str] = Field(None, description="Asset description")
+    type: Optional[str] = Field(None, description="Media type")
+    roles: Optional[List[str]] = Field(None, description="Asset roles")
+
+
 class STACCollection(BaseModel):
     """STAC Collection response model."""
 
@@ -144,7 +154,7 @@ class STACCollection(BaseModel):
     summaries: Optional[Dict[str, Any]] = Field(
         None, description="Collection summaries"
     )
-    assets: Optional[Dict[str, Any]] = Field(
+    assets: Optional[Dict[str, "STACAsset"]] = Field(
         None, description="Collection assets"
     )
     model_config = ConfigDict(

--- a/tests/client/test_databrowser_cli.py
+++ b/tests/client/test_databrowser_cli.py
@@ -15,7 +15,6 @@ import zipfile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import namegenerator
 from py_oidc_auth_client import Token
 from pytest import LogCaptureFixture
 from pytest_mock import MockerFixture
@@ -665,7 +664,8 @@ class TestFlavourCommands:
             "use_token"
         )
 
-        flavour_name = namegenerator.gen()
+        from freva_rest.utils.namegenerator import generate_names
+        flavour_name = generate_names()
         res = cli_runner.invoke(
             app,
             [

--- a/tests/client/test_databrowser_py.py
+++ b/tests/client/test_databrowser_py.py
@@ -12,7 +12,6 @@ Authentication is handled via the ``mock_authenticate`` /
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import namegenerator
 import pandas as pd
 import pytest
 from py_oidc_auth_client import Token
@@ -520,7 +519,8 @@ class TestFlavourOperations:
     ) -> None:
         """Test the full lifecycle: list, add, update, rename, delete."""
         # list existing flavours
-        flavour_name = namegenerator.gen()
+        from freva_rest.utils.namegenerator import generate_names
+        flavour_name = generate_names()
         mocker.patch("freva_client.utils.choose_token_strategy").return_value = (
             "use_token"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ from data_portal_worker.load_data import RedisCacheFactory as Cache
 from freva_client.utils import logger
 from freva_rest.api import app
 from freva_rest.config import ServerConfig
-from freva_rest.databrowser_api.mock import read_data
+from freva_rest.databrowser_api.mock import read_data, read_static
 from freva_rest.logger import reset_loggers
 
 
@@ -48,6 +48,7 @@ def load_data() -> None:
     conf = ServerConfig(debug=True)
     for core in conf.solr_cores:
         asyncio.run(read_data(core, conf.solr_url))
+    asyncio.run(read_static(conf.solr_url))
 
 
 def run_test_server(port: int) -> None:

--- a/tests/rest/test_stacapi.py
+++ b/tests/rest/test_stacapi.py
@@ -7,30 +7,55 @@ import requests
 
 def test_stacapi_basic(test_server: str) -> None:
     """Test the default stacapi functionality."""
-    result_catalog = requests.get(f"{test_server}/stacapi/")
+    result_catalog = requests.get(f"{test_server}/stacapi/freva/")
     assert result_catalog.json()["stac_version"] == "1.0.0"
     assert result_catalog.json()["type"] == "Catalog"
 
-    result_collections = requests.get(f"{test_server}/stacapi/collections")
+    result_collections = requests.get(f"{test_server}/stacapi/freva/collections")
     assert isinstance(result_collections.json()["collections"], list)
     assert len(result_collections.json()["links"]) > 0
 
-    result_collection = requests.get(f"{test_server}/stacapi/collections/cmip6")
+    result_collection = requests.get(f"{test_server}/stacapi/freva/collections/cmip6")
     assert result_collection.status_code == 200
     assert result_collection.json()["id"] == "cmip6"
     assert result_collection.json()["stac_version"] == "1.1.0"
     assert result_collection.json()["type"] == "Collection"
 
-    result_items = requests.get(f"{test_server}/stacapi/collections/cmip6/items")
+    assert "assets" in result_collection.json()
+    assert "metadata" in result_collection.json()["assets"]
+
+    result_items = requests.get(f"{test_server}/stacapi/freva/collections/cmip6/items")
     assert result_items.status_code == 200
     assert isinstance(result_items.json()["features"], list)
     assert len(result_items.json()["features"]) > 0
     assert result_items.json()["type"] == "FeatureCollection"
 
 
+def test_stacapi_static_enrichment(test_server: str) -> None:
+    """Test that collections are enriched from the static core when available."""
+    res = requests.get(f"{test_server}/stacapi/freva/collections/cmip6")
+    assert res.status_code == 200
+    data = res.json()
+    # if static core is seeded, title and description come from it
+    # if not, fallback values are used
+    assert data["title"]
+    assert data["description"]
+    assert data["license"]
+    assert isinstance(data["extent"]["spatial"]["bbox"][0], list)
+    assert len(data["extent"]["spatial"]["bbox"][0]) == 4
+    # thumbnail asset and preview link only present when static data has thumbnail_url
+    if data.get("assets", {}).get("thumbnail"):
+        assert data["assets"]["thumbnail"]["roles"] == ["thumbnail"]
+        preview_rels = [l["rel"] for l in data["links"]]
+        assert "preview" in preview_rels
+    # documentation asset only present when static data has documentation_url
+    if data.get("assets", {}).get("documentation"):
+        assert data["assets"]["documentation"]["roles"] == ["overview"]
+
+
 def test_stacapi_conformance(test_server: str) -> None:
     """Test the default stacapi conformance functionality."""
-    result = requests.get(f"{test_server}/stacapi/conformance")
+    result = requests.get(f"{test_server}/stacapi/freva/conformance")
     assert result.status_code == 200
     assert isinstance(result.json()["conformsTo"], list)
     assert len(result.json()["conformsTo"]) > 0
@@ -44,48 +69,48 @@ def test_stacapi_conformance(test_server: str) -> None:
 def test_stacapi_item_params(test_server: str) -> None:
     """Test the default stacapi item parameters functionality."""
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items", params={"limit": 1}
+        f"{test_server}/stacapi/freva/collections/cmip6/items", params={"limit": 1}
     )
     assert result.status_code == 200
     assert len(result.json()["features"]) == 1
 
     # invalid parameter
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items", params={"limit": 0}
+        f"{test_server}/stacapi/freva/collections/cmip6/items", params={"limit": 0}
     )
     assert result.status_code == 422
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items", params={"limitx": 1001}
+        f"{test_server}/stacapi/freva/collections/cmip6/items", params={"limitx": 1001}
     )
     assert result.status_code == 422
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items",
+        f"{test_server}/stacapi/freva/collections/cmip6/items",
         params={"datetime": "2023-10-01/2023-10-31", "bbox": "10,20,30,40"},
     )
     assert result.status_code == 200
     assert isinstance(result.json()["features"], list)
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items",
+        f"{test_server}/stacapi/freva/collections/cmip6/items",
         params={"datetime": "2023-10-01", "bbox": "10,20,30,40"},
     )
     assert result.status_code == 200
     assert isinstance(result.json()["features"], list)
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items",
+        f"{test_server}/stacapi/freva/collections/cmip6/items",
         params={"datetime": "/2023-10-01", "bbox": "10,20,30,40"},
     )
     assert result.status_code == 422
 
     # test the next and previous token
-    result_get = requests.get(f"{test_server}/stacapi/collections/cordex/items")
+    result_get = requests.get(f"{test_server}/stacapi/freva/collections/cordex/items")
     cordex_length = len(result_get.json().get("features"))
     last_item_id = result_get.json().get("features")[cordex_length - 1].get("id")
     result = requests.get(
-        f"{test_server}/stacapi/collections/cordex/items",
+        f"{test_server}/stacapi/freva/collections/cordex/items",
         params={"limit": 1, "token": f"prev:cordex:{last_item_id}"},
     )
     assert result.status_code == 200
@@ -93,20 +118,20 @@ def test_stacapi_item_params(test_server: str) -> None:
 
     first_item_id = result_get.json().get("features")[0].get("id")
     result = requests.get(
-        f"{test_server}/stacapi/collections/cordex/items",
+        f"{test_server}/stacapi/freva/collections/cordex/items",
         params={"limit": 1, "token": f"next:cordex:{first_item_id}"},
     )
     assert result.status_code == 200
     assert len(result.json()["features"]) == 1
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cordex/items",
+        f"{test_server}/stacapi/freva/collections/cordex/items",
         params={"limit": 1, "token": f"wrong_direction:cordex:{last_item_id}"},
     )
     assert result.status_code == 422
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cordex/items",
+        f"{test_server}/stacapi/freva/collections/cordex/items",
         params={"limit": 1, "token": f"wrong_direction:cordex:"},
     )
     assert result.status_code == 422
@@ -115,25 +140,25 @@ def test_stacapi_item_params(test_server: str) -> None:
 def test_stacapi_staccheck(test_server: str) -> None:
     """Test the stacapi staccheck functionality."""
     result_output = subprocess.run(
-        ["stac-check", f"{test_server}/stacapi/"], check=True, capture_output=True
+        ["stac-check", f"{test_server}/stacapi/freva/"], check=True, capture_output=True
     )
     assert "CATALOG Passed: True" in result_output.stdout.decode("utf-8")
 
     result_output = subprocess.run(
-        ["stac-check", f"{test_server}/stacapi/collections/cmip6/"],
+        ["stac-check", f"{test_server}/stacapi/freva/collections/cmip6/"],
         check=True,
         capture_output=True,
     )
     assert "COLLECTION Passed: True" in result_output.stdout.decode("utf-8")
 
     result_get = requests.get(
-        f"{test_server}/stacapi/collections/nextgems/items?limit=1"
+        f"{test_server}/stacapi/freva/collections/nextgems/items?limit=1"
     )
     item_id = result_get.json().get("features")[0].get("id")
     result_output = subprocess.run(
         [
             "stac-check",
-            f"{test_server}/stacapi/collections/nextgems/items/{item_id}/",
+            f"{test_server}/stacapi/freva/collections/nextgems/items/{item_id}/",
         ],
         check=True,
         capture_output=True,
@@ -144,18 +169,18 @@ def test_stacapi_staccheck(test_server: str) -> None:
 
 def test_stacapi_fail(test_server: str) -> None:
     """Test the stacapi fail functionality."""
-    result = requests.get(f"{test_server}/stacapi/collections/cmip69/")
+    result = requests.get(f"{test_server}/stacapi/freva/collections/cmip69/")
     assert result.status_code == 404
 
     result = requests.get(
-        f"{test_server}/stacapi/collections/cmip6/items/wrong_item_id"
+        f"{test_server}/stacapi/freva/collections/cmip6/items/wrong_item_id"
     )
     assert result.status_code == 404
 
 
 def test_stacapi_search_get(test_server: str) -> None:
     """Test the STAC API search GET endpoint."""
-    res1 = requests.get(f"{test_server}/stacapi/search")
+    res1 = requests.get(f"{test_server}/stacapi/freva/search")
     assert res1.status_code == 200
     data = res1.json()
     assert "features" in data
@@ -163,20 +188,20 @@ def test_stacapi_search_get(test_server: str) -> None:
     assert data["type"] == "FeatureCollection"
 
     res2 = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"collections": "cmip6", "limit": 5},
     )
     assert res2.status_code == 200
 
     res3 = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"bbox": "10,20,30,40", "limit": 3},
     )
     assert res3.status_code == 200
 
     # Invalid bbox format
     res4 = requests.get(
-        f"{test_server}/stacapi/search", params={"bbox": "invalid_bbox"}
+        f"{test_server}/stacapi/freva/search", params={"bbox": "invalid_bbox"}
     )
     assert res4.status_code == 422
 
@@ -184,56 +209,56 @@ def test_stacapi_search_get(test_server: str) -> None:
 def test_stacapi_search_post(test_server: str) -> None:
     """Test the STAC API search POST endpoint."""
     search_body = {"limit": 5}
-    res1 = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res1 = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res1.status_code == 200
     data = res1.json()
     assert "features" in data
     assert "type" in data
 
     search_body = {"collections": ["cmip6"], "limit": 3}
-    res2 = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res2 = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res2.status_code == 200
 
     search_body = {"bbox": [10, 20, 30, 40], "limit": 2}
-    res3 = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res3 = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res3.status_code == 200
 
     # Invalid POST body
-    res4 = requests.post(f"{test_server}/stacapi/search", json={"limit": 0})
+    res4 = requests.post(f"{test_server}/stacapi/freva/search", json={"limit": 0})
     assert res4.status_code == 422
 
     # POST search with Free Text Search list
     search_body = {"q": "[cmip, temperature]", "limit": 2}
-    res5 = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res5 = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res5.status_code == 200
 
     search_body = {"q": "cmip", "limit": 2}
-    res6 = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res6 = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res6.status_code == 200
 
 
 def test_stacapi_queryables(test_server: str) -> None:
     """Test the STAC API queryables endpoints."""
-    res1 = requests.get(f"{test_server}/stacapi/queryables")
+    res1 = requests.get(f"{test_server}/stacapi/freva/queryables")
     assert res1.status_code == 200
     data = res1.json()
     assert "$schema" in data
     assert "properties" in data
 
-    res2 = requests.get(f"{test_server}/stacapi/collections/cmip6/queryables")
+    res2 = requests.get(f"{test_server}/stacapi/freva/collections/cmip6/queryables")
     assert res2.status_code == 200
     data = res2.json()
     assert "$schema" in data
     assert "properties" in data
 
     # Invalid collection queryables
-    res3 = requests.get(f"{test_server}/stacapi/collections/invalid/queryables")
+    res3 = requests.get(f"{test_server}/stacapi/freva/collections/invalid/queryables")
     assert res3.status_code == 404
 
 
 def test_stacapi_ping(test_server: str) -> None:
     """Test the nextgen STAC API ping endpoint."""
-    res = requests.get(f"{test_server}/stacapi/_mgmt/ping")
+    res = requests.get(f"{test_server}/stacapi/freva/_mgmt/ping")
     assert res.status_code == 200
     data = res.json()
     assert data["message"] == "PONG"
@@ -243,32 +268,32 @@ def test_stacapi_search_params(test_server: str) -> None:
     """Test the nextgen STAC API search parameter validation."""
 
     res1 = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"datetime": "2023-01-01/2023-12-31", "limit": 2},
     )
     assert res1.status_code == 200
 
     res2 = requests.get(
-        f"{test_server}/stacapi/search", params={"ids": "some_id", "limit": 1}
+        f"{test_server}/stacapi/freva/search", params={"ids": "some_id", "limit": 1}
     )
     assert res2.status_code == 200
 
     # with free text search
     res3 = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"q": "climate,temperature", "limit": 2},
     )
     assert res3.status_code == 200
 
     res4 = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"token": "next:search:some_id", "limit": 1},
     )
     assert res4.status_code == 200
 
     # Invalid token format
     res5 = requests.get(
-        f"{test_server}/stacapi/search", params={"token": "invalid_token_format"}
+        f"{test_server}/stacapi/freva/search", params={"token": "invalid_token_format"}
     )
     assert res5.status_code == 422
 
@@ -289,7 +314,7 @@ def test_stacapi_search_filter(test_server: str) -> None:
 
     for filter_json in filters:
         res = requests.get(
-            f"{test_server}/stacapi/search",
+            f"{test_server}/stacapi/freva/search",
             params={"filter": filter_json, "limit": 2},
         )
         assert res.status_code == 200
@@ -321,7 +346,7 @@ def test_stacapi_search_filter(test_server: str) -> None:
             ],
         },
     }
-    res = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res.status_code == 200
 
     # t_after, t_before, t_during
@@ -396,7 +421,7 @@ def test_stacapi_search_filter(test_server: str) -> None:
                 ],
             },
         }
-        res = requests.post(f"{test_server}/stacapi/search", json=search_body)
+        res = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
         assert res.status_code == 200
 
     # filter + collections + bbox + datetime
@@ -407,7 +432,7 @@ def test_stacapi_search_filter(test_server: str) -> None:
         "limit": 2,
         "filter": {"op": "=", "args": [{"property": "realm"}, "atmos"]},
     }
-    res = requests.post(f"{test_server}/stacapi/search", json=search_body)
+    res = requests.post(f"{test_server}/stacapi/freva/search", json=search_body)
     assert res.status_code == 200
 
     # empty filters errors
@@ -552,7 +577,7 @@ def test_stacapi_search_filter(test_server: str) -> None:
 
     for case in error_cases:
         res = requests.post(
-            f"{test_server}/stacapi/search", json={**case, "limit": 1}
+            f"{test_server}/stacapi/freva/search", json={**case, "limit": 1}
         )
         assert res.status_code == 200
 
@@ -585,13 +610,13 @@ def test_stacapi_search_filter(test_server: str) -> None:
 
     for case in mapping_tests:
         res = requests.post(
-            f"{test_server}/stacapi/search", json={**case, "limit": 1}
+            f"{test_server}/stacapi/freva/search", json={**case, "limit": 1}
         )
         assert res.status_code == 200
 
     # Invalid JSON
     res = requests.get(
-        f"{test_server}/stacapi/search",
+        f"{test_server}/stacapi/freva/search",
         params={"filter": "invalid_json", "limit": 1},
     )
     assert res.status_code == 200


### PR DESCRIPTION
This PR introduces two main changes.

As first feature, it brings the concept of translators (“flavours”) into the STAC API. The main goal is to support a request from the ESGF group. They want to deploy Freva, and as a result the STAC API, on their side while continuing to use the Solr search engine but with a different `managed_schema.xml`. With this PR, after deployment they can define a new global flavour called `ESGF` and map the existing `freva` facets to ESGF facets without any need to have new managed_schema or modify anything there. This would also let them to expose a STAC API endpoint such as `/api/freva-nextgen/stacapi/esgf`.

But still there is one important caveat that we couldn't find a solid solution for: the number of facets currently available in our main `managed_schema.xml` is smaller than the number of metadata fields used by `ESGF`. ESGF has roughly 58 metadata keys, which is more than what we currently expose in our managed schema. So even with translation in place, we still cannot represent all ESGF metadata one-to-one. On the positive side, a quick comparison shows that some ESGF facets may not be strictly necessary for our use case, and some are simply represented differently. For example, ESGF defines the bounding box as four separate facets, while in Freva we represent it as a single `bbox` field. There are several similar cases like this. Hopefully after a discussion with them we probably can get to a conclusion on the number of keys.

As a second change, for the Waterfall project, this PR adds support for reading constant collection metadata from a `static` Solr core, as introduced in [freva-service-config PR #85](https://github.com/freva-org/freva-service-config/pull/85). This makes catalog curation much easier and let the process to be handled automatically. If that PR is not approved or the `static` core cannot be reached, this PR still works correctly because it automatically falls back to the default values that were already defined before.

Also the other benefit is, once [freva-service-config PR #85](https://github.com/freva-org/freva-service-config/pull/85) is approved, we can also add a new table to the nightly automatic crawler (`-general`) for our currently running instances, so that updated `static` metadata can be crawled and ingested automatically into the deployed freva instances and STACAPI can have thumbnails and long description and so on.

