### PR TITLE
fix: pass app_name as keyword argument to TokenStore

### DIFF
--- a/freva-client/src/freva_client/utils/__init__.py
+++ b/freva-client/src/freva_client/utils/__init__.py
@@ -60,7 +60,7 @@ class AuthConfig:
 
     def __init__(self, host: str, _redirect_ports: List[int] = []):
 
-        self.token_db = TokenStore(self.app_name)
+        self.token_db = TokenStore(app_name=self.app_name)
         host = self.get_rest_host(host)
         kwargs: Dict[str, Union[str, List[int]]] = {"app_name": self.app_name}
         if not _redirect_ports:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,7 +191,7 @@ def setup_server() -> Iterator[str]:
 
 
 @pytest.fixture(scope="function", autouse=True)
-def user_cache_dir() -> Iterator[str]:
+def user_cache_dir(tmp_path) -> Iterator[str]:
     """Mock the default user token file for each test.
 
     A temporary file is created and the TOKEN_ENV_VAR environment variable is
@@ -201,8 +201,11 @@ def user_cache_dir() -> Iterator[str]:
         with mock.patch.dict(
             os.environ, {"OIDC_TOKEN_FILE": temp_f.name}, clear=False
         ):
-            yield temp_f.name
-
+            with mock.patch(
+                "py_oidc_auth_client.token_store.user_cache_path",
+                return_value=tmp_path,
+            ):
+                yield temp_f.name
 
 @pytest.fixture(scope="function")
 def temp_dir() -> Iterator[Path]:


### PR DESCRIPTION
`TokenStore(self.app_name)` was passing "freva" as the `path` argument instead of `app_name`, causing tokens to be written to a file literally named `freva` in the current working directory rather than to
`~/.cache/token-store.json`.

This meant the token cache was never found on subsequent calls, forcing a new browser-based auth flow every time and breaking non-interactive use cases.
