### PR TITLE
Hotfix: Rename `data_type` to `freva:data_type` in STAC item properties

### DIFF
--- a/freva-rest/src/freva_rest/stac_api/core.py
+++ b/freva-rest/src/freva_rest/stac_api/core.py
@@ -526,7 +526,7 @@ class STACAPI:
 
         properties = {
             **{
-                k: result.get(k)
+                ("freva:data_type" if k == "data_type" else k): result.get(k)
                 for k in self.config.solr_fields
                 if k in result and result.get(k) is not None
             },


### PR DESCRIPTION
The newly added Solr field [`data_type` (default: `"model-data"`)](https://github.com/freva-org/freva-service-config/blob/main/solr/managed-schema.xml#L95) conflicts with a reserved STAC EO extension field of the same name, which enforces a strict enum of valid values; causing `stac-check` to fail item validation.

Two fixes were considered: 1. removing the `stac-check` tests entirely, or 2. renaming the field in STAC item properties to avoid the conflict. We chose the latter, renaming `data_type` -> `freva:data_type` when building item properties, so `stac-check` stays in place and can continue catching this class of error in the future.