### PR TITLE
hotfix: enforce system user access gate in systemuser endpoint

### DIFF
--- a/freva-client/src/freva_client/query.py
+++ b/freva-client/src/freva_client/query.py
@@ -1275,7 +1275,7 @@ class databrowser:
             overview["Note"] = note
         overview["Available search flavours"] = overview.pop("flavours")
         overview["Search attributes by flavour"] = overview.pop("attributes")
-        return yaml.safe_dump(overview, sort_keys=False)
+        return cast(str, yaml.safe_dump(overview, sort_keys=False))
 
     @property
     def url(self) -> str:

--- a/freva-rest/src/freva_rest/auth.py
+++ b/freva-rest/src/freva_rest/auth.py
@@ -126,6 +126,8 @@ async def systemuser(
         raise HTTPException(403, detail="Token expired.")
     _user = get_userinfo(payload)
     username = _user_claim_check.search(payload)
+    if not username:
+        raise HTTPException(403, detail="Not a system user.")
     return SystemUser(
         username=username or current_user.preferred_username or "",
         email=_user.get("email", current_user.email or ""),


### PR DESCRIPTION
While adjusting the web guest user flow, a potential security hole for third-party IDP users came to light. The `systemuser` endpoint was returning 200 for any authenticated user regardless of whether they matched the configured `oidc_systemuser_claim`. A 403 guard has been added when the JMESPath expression returns no match, so only users satisfying the claim condition (e.g. membership in the `ch1187` group) are recognized as system users. If `oidc_systemuser_claim` is not set, everyone is treated as a regular user.
This doesn't affect filesystem-level access on the crucial data-loader, since usernames are verified via `pwd` there and `systemyuser` has not been used there, but it adds a guard at the web layer, e.g. for the plugin submission button.