### PR TITLE
hotfix: keep the logs on debug level _cache_manager.py

### DIFF
--- a/freva-data-portal-worker/src/data_portal_worker/_cache_manager.py
+++ b/freva-data-portal-worker/src/data_portal_worker/_cache_manager.py
@@ -19,7 +19,7 @@ def run_cache_cleanup(force: bool = False) -> None:
 
         xarray_prism.clear_cache()
         info = xarray_prism.cache_info()
-        data_logger.info(
+        data_logger.debug(
             "Cache cleanup done: %d file(s), %.1f MB remaining at %s",
             info["files"],
             info["size_bytes"] / 1024**2,


### PR DESCRIPTION
This PR is going to vanish the info logs of prism on data-loder.