### PR TITLE
Use backend_kwargs to propagate decode options

### DIFF
--- a/freva-data-portal-worker/src/data_portal_worker/backends/posix_and_cloud.py
+++ b/freva-data-portal-worker/src/data_portal_worker/backends/posix_and_cloud.py
@@ -11,14 +11,12 @@ def posix_and_cloud(
     inp_file: Union[str, Path], chunk_size: float = 16.0, **kwargs: Any
 ) -> xr.Dataset:
     """Open a dataset with xarray."""
-    engine = "prism"
     inp_str = str(inp_file)
     parsed = urlparse(inp_str)
     target: Union[str, Path]
     target = Path(inp_str) if parsed.scheme in ("", "file") else inp_str
     _ = kwargs.pop("chunks", None)
-    for key in ("decode_cf", "cache", "decode_coords"):
-        kwargs[key] = False
+    kwargs['backend_kwargs'] = { key: False for key in ("decode_cf", "decode_coords")}
+    kwargs['cache']=False
     kwargs["chunks"] = "auto"
-    kwargs["engine"] = engine
-    return xr.open_dataset(target, **kwargs).unify_chunks()
+    return xr.open_dataset(target, engine='prism', **kwargs).unify_chunks()


### PR DESCRIPTION
A workaround for https://github.com/freva-org/xarray-prism/issues/6